### PR TITLE
rendering <noscript> in case of rendering to null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import linkClass from './linkClass';
+import React from 'react';
 import _ from 'lodash';
 
 let decoratorConstructor,
@@ -15,7 +16,8 @@ let decoratorConstructor,
 functionConstructor = (Component, defaultStyles, options) => {
     return class extends Component {
         render () {
-            let styles;
+            let renderResult,
+                styles;
 
             if (this.props.styles) {
                 styles = this.props.styles;
@@ -25,7 +27,13 @@ functionConstructor = (Component, defaultStyles, options) => {
                 styles = {};
             }
 
-            return linkClass(super.render(), styles, options);
+            renderResult = super.render();
+
+            if (renderResult) {
+                return linkClass(renderResult, styles, options);
+            }
+
+            return React.createElement('noscript');
         }
     };
 };

--- a/test/reactCssModules.js
+++ b/test/reactCssModules.js
@@ -1,0 +1,57 @@
+import {
+    expect
+} from 'chai';
+
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import reactCssModules from './../src/index';
+
+describe('reactCssModules', () => {
+    context('when a ReactComponent renders an element with the styleName prop', () => {
+        it('that element should contain the equivalent className', () => {
+            let Foo,
+                component,
+                shallowRenderer;
+
+            shallowRenderer = TestUtils.createRenderer();
+
+            Foo = reactCssModules(class extends React.Component {
+                render () {
+                    return <div styleName='foo'>Hello</div>;
+                }
+            }, {
+                foo: 'foo-1'
+            });
+
+            shallowRenderer.render(<Foo />);
+
+            component = shallowRenderer.getRenderOutput();
+
+            expect(component.props.className).to.equal('foo-1');
+        });
+    });
+
+    context('when a ReactComponent renders nothing', () => {
+        it('linkClass should not intervene', () => {
+            let Foo,
+                component,
+                shallowRenderer;
+
+            shallowRenderer = TestUtils.createRenderer();
+
+            Foo = reactCssModules(class extends React.Component {
+                render () {
+                    return null;
+                }
+            }, {
+                foo: 'foo-1'
+            });
+
+            shallowRenderer.render(<Foo />);
+
+            component = shallowRenderer.getRenderOutput();
+
+            expect(typeof component).to.equal('object');
+        });
+    });
+});


### PR DESCRIPTION
Hi @gajus first of all, thank you so much for all the work!

I've stumbled upon an error on my app when I started using CSSModules(MyComponent, styles) to render certain Components that given certain conditions would return null, when rendering.

Made some changes to the "src/index.js" file, according to what React 0.11 did for the "Rendering to null" case.

Made some tests too.