### PR TITLE
allow null elements from render methods

### DIFF
--- a/dist/linkClass.js
+++ b/dist/linkClass.js
@@ -36,6 +36,10 @@ linkClass = function (element, styles, userConfiguration) {
         newProps = undefined,
         styleNames = undefined;
 
+    if (!element) {
+        return element;
+    }
+
     configuration = (0, _makeConfiguration2['default'])(userConfiguration);
 
     styleNames = element.props.styleName;

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -18,6 +18,10 @@ linkClass = (element, styles = {}, userConfiguration) => {
         newProps,
         styleNames;
 
+    if (!element) {
+        return element;
+    }
+
     configuration = makeConfiguration(userConfiguration);
 
     styleNames = element.props.styleName;


### PR DESCRIPTION
If you wrap a component that sometimes returns `null` in its render (which is perfectly valid), then `linkClass` will choke when it tries to get `element.props` when the component is rendering `null`. This truthy check fixes that.