### PR TITLE
trim `styleName` before split

### DIFF
--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -23,7 +23,7 @@ linkClass = (element, styles = {}, userConfiguration) => {
     styleNames = element.props.styleName;
 
     if (styleNames) {
-        styleNames = styleNames.split(' ');
+        styleNames = styleNames.trim().split(' ');
 
         if (configuration.allowMultiple === false && styleNames.length > 1) {
             throw new Error(`ReactElement styleName property defines multiple module names ("${element.props.styleName}").`);


### PR DESCRIPTION
more similar to behavior of `className` in the browser.

(untested btw, just making a spur-of-the-moment PR since i ran into an error this change theoretically would have avoided. :)