### PR TITLE
allow array for styleName

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,3 +536,9 @@ That said, if you require to use multiple CSS Modules to describe an element, en
 ```
 
 This will map both [Interoperable CSS](https://github.com/css-modules/icss) CSS classes to the target element.
+
+You can also use an array instead of concatenated string (might be useful for conditional styling).
+
+```js
+<div styleName={['button', 'active']} />
+```

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -25,12 +25,15 @@ linkClass = (element, styles = {}, userConfiguration) => {
 
     configuration = makeConfiguration(userConfiguration);
 
-    styleNames = element.props.styleName;
+    styleNames = element.props.styleName || [];
 
-    if (styleNames) {
+    if (!Array.isArray(styleNames)) {
         styleNames = styleNames.split(' ');
-        styleNames = _.filter(styleNames);
+    }
 
+    styleNames = _.filter(styleNames);
+
+    if (styleNames.length > 0) {
         if (configuration.allowMultiple === false && styleNames.length > 1) {
             throw new Error(`ReactElement styleName property defines multiple module names ("${element.props.styleName}").`);
         }

--- a/test/linkClass.js
+++ b/test/linkClass.js
@@ -177,6 +177,18 @@ describe('linkClass', () => {
 
                     expect(subject.props.className).to.deep.equal('foo-1 bar-1');
                 });
+                it('allows CSS modules to be specified as an array', () => {
+                    let subject;
+
+                    subject = <div styleName={['foo', 'bar']}></div>;
+
+                    subject = linkClass(subject, {
+                        foo: 'foo-1',
+                        bar: 'bar-1'
+                    }, {allowMultiple: true});
+
+                    expect(subject.props.className).to.deep.equal('foo-1 bar-1');
+                });
             });
         });
     });


### PR DESCRIPTION
Yeah, I've read about using composition over multiple style names, but I just don't see how to apply that easily in my case. I have an element that can have like 4 different states, some can be even combined. With composition I would need to create combination for every case and that would make my conditions kinda a messy.

```css
.bullet {
    width: 15px;
    height: 18px;
}
.bulletZoom {
    cursor: pointer;
}
.bulletZoom:hover {
    background-color: #aaa;
}
.bulletChildren {
    background-color: #ddd;
}
.bulletSelected {
    color: red;
}
.bulletError {
    color: #aaa;
}
```

If you have a suggestion how to handles this using composition, I would to hear that. Otherwise I could really use this pull request so I don't need to concatenate style names just to be split later.