### PR TITLE
hoist static properties of stateless functions

### DIFF
--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -12,7 +12,9 @@ let wrapStatelessFunction;
  * @returns {function}
  */
 wrapStatelessFunction = (Component, defaultStyles, options) => {
-    return (props = {}, ...args) => {
+    let WrappedComponent;
+
+    WrappedComponent = (props = {}, ...args) => {
         let renderResult,
             styles,
             useProps;
@@ -39,6 +41,10 @@ wrapStatelessFunction = (Component, defaultStyles, options) => {
 
         return React.createElement('noscript');
     };
+
+    _.assign(WrappedComponent, Component);
+
+    return WrappedComponent;
 };
 
 export default wrapStatelessFunction;

--- a/test/wrapStatelessFunction.js
+++ b/test/wrapStatelessFunction.js
@@ -7,6 +7,23 @@ import {
 import wrapStatelessFunction from './../src/wrapStatelessFunction';
 
 describe('wrapStatelessFunction', () => {
+    it('hoists static own properties from the input component to the wrapped component', () => {
+        let Component, WrappedComponent, styles;
+
+        styles = {
+            foo: 'foo-1'
+        };
+
+        Component = function InnerComponent () { return null; };
+        Component.propTypes = {};
+        Component.defaultProps = {};
+
+        WrappedComponent = wrapStatelessFunction(Component, styles);
+
+        expect(WrappedComponent.propTypes).to.equal(Component.propTypes);
+        expect(WrappedComponent.defaultProps).to.equal(Component.defaultProps);
+        expect(WrappedComponent.name).not.to.equal(Component.name);
+    });
     context('using default styles', () => {
         it('exposes styles through styles property', (done) => {
             let styles;


### PR DESCRIPTION
Addresses #46

`_.assign()` only copies own enumerable props so things the user adds like `defaultProps` and `propTypes` will be copied to the wrapped component, but built-in props and non-own props like `name` and `prototype` will not.