### PR TITLE
Browser Support for global variable "ReactCssModules".

### DIFF
--- a/min/react-css-modules.js
+++ b/min/react-css-modules.js
@@ -1,0 +1,3002 @@
+window.ReactCssModules = /******/ (function(modules) { // webpackBootstrap
+    /******/ 	// The module cache
+    /******/ 	var installedModules = {};
+
+    /******/ 	// The require function
+    /******/ 	function __ReactCssModules_require__(moduleId) {
+
+        /******/ 		// Check if module is in cache
+        /******/ 		if(installedModules[moduleId])
+        /******/ 			return installedModules[moduleId].exports;
+
+        /******/ 		// Create a new module (and put it into the cache)
+        /******/ 		var module = installedModules[moduleId] = {
+            /******/ 			exports: {},
+            /******/ 			id: moduleId,
+            /******/ 			loaded: false
+            /******/ 		};
+
+        /******/ 		// Execute the module function
+        /******/ 		modules[moduleId].call(module.exports, module, module.exports, __ReactCssModules_require__);
+
+        /******/ 		// Flag the module as loaded
+        /******/ 		module.loaded = true;
+
+        /******/ 		// Return the exports of the module
+        /******/ 		return module.exports;
+        /******/ 	}
+
+
+    /******/ 	// expose the modules object (__webpack_modules__)
+    /******/ 	__ReactCssModules_require__.m = modules;
+
+    /******/ 	// expose the module cache
+    /******/ 	__ReactCssModules_require__.c = installedModules;
+
+    /******/ 	// __webpack_public_path__
+    /******/ 	__ReactCssModules_require__.p = "";
+
+    /******/ 	// Load entry module and return exports
+    /******/ 	return __ReactCssModules_require__(0);
+    /******/ })
+/************************************************************************/
+/******/ ([
+    /* 0 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _isFunction = __ReactCssModules_require__(1);
+
+        var _isFunction2 = _interopRequireDefault(_isFunction);
+
+        var _extendReactClass = __ReactCssModules_require__(3);
+
+        var _extendReactClass2 = _interopRequireDefault(_extendReactClass);
+
+        var _wrapStatelessFunction = __ReactCssModules_require__(69);
+
+        var _wrapStatelessFunction2 = _interopRequireDefault(_wrapStatelessFunction);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        var decoratorConstructor = undefined,
+            functionConstructor = undefined,
+            isReactComponent = undefined;
+
+        /**
+         * Determines if the given object has the signature of a class that inherits React.Component.
+         *
+         * @param {*} Component
+         * @return {boolean}
+         */
+        isReactComponent = function (Component) {
+            return 'prototype' in Component && (0, _isFunction2.default)(Component.prototype.render);
+        };
+
+        /**
+         * When used as a function.
+         *
+         * @param {Function} Component
+         * @param {Object} defaultStyles CSS Modules class map.
+         * @param {Object} options {@link https://github.com/gajus/react-css-modules#options}
+         * @return {Function}
+         */
+        functionConstructor = function (Component, defaultStyles, options) {
+            var decoratedClass = undefined;
+
+            if (isReactComponent(Component)) {
+                decoratedClass = (0, _extendReactClass2.default)(Component, defaultStyles, options);
+            } else {
+                decoratedClass = (0, _wrapStatelessFunction2.default)(Component, defaultStyles, options);
+            }
+
+            if (Component.displayName) {
+                decoratedClass.displayName = Component.displayName;
+            } else {
+                decoratedClass.displayName = Component.name;
+            }
+
+            return decoratedClass;
+        };
+
+        /**
+         * When used as a ES7 decorator.
+         *
+         * @param {Object} defaultStyles CSS Modules class map.
+         * @param {Object} options {@link https://github.com/gajus/react-css-modules#options}
+         * @return {Function}
+         */
+        decoratorConstructor = function (defaultStyles, options) {
+            return function (Component) {
+                return functionConstructor(Component, defaultStyles, options);
+            };
+        };
+
+        exports.default = function () {
+            if ((0, _isFunction2.default)(arguments[0])) {
+                return functionConstructor(arguments[0], arguments[1], arguments[2]);
+            } else {
+                return decoratorConstructor(arguments[0], arguments[1]);
+            }
+        };
+        //# sourceMappingURL=index.js.map
+
+
+        /***/ },
+    /* 1 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isObject = __ReactCssModules_require__(2);
+
+        /** `Object#toString` result references. */
+        var funcTag = '[object Function]';
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /**
+         * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+         * of values.
+         */
+        var objToString = objectProto.toString;
+
+        /**
+         * Checks if `value` is classified as a `Function` object.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+         * @example
+         *
+         * _.isFunction(_);
+         * // => true
+         *
+         * _.isFunction(/abc/);
+         * // => false
+         */
+        function isFunction(value) {
+            // The use of `Object#toString` avoids issues with the `typeof` operator
+            // in older versions of Chrome and Safari which return 'function' for regexes
+            // and Safari 8 which returns 'object' for typed array constructors.
+            return isObject(value) && objToString.call(value) == funcTag;
+        }
+
+        module.exports = isFunction;
+
+
+        /***/ },
+    /* 2 */
+    /***/ function(module, exports) {
+
+        /**
+         * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+         * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+         * @example
+         *
+         * _.isObject({});
+         * // => true
+         *
+         * _.isObject([1, 2, 3]);
+         * // => true
+         *
+         * _.isObject(1);
+         * // => false
+         */
+        function isObject(value) {
+            // Avoid a V8 JIT bug in Chrome 19-20.
+            // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
+            var type = typeof value;
+            return !!value && (type == 'object' || type == 'function');
+        }
+
+        module.exports = isObject;
+
+
+        /***/ },
+    /* 3 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+        var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _assign = __ReactCssModules_require__(4);
+
+        var _assign2 = _interopRequireDefault(_assign);
+
+        var _isObject = __ReactCssModules_require__(2);
+
+        var _isObject2 = _interopRequireDefault(_isObject);
+
+        var _linkClass = __ReactCssModules_require__(26);
+
+        var _linkClass2 = _interopRequireDefault(_linkClass);
+
+        var _react = __ReactCssModules_require__(61);
+
+        var _react2 = _interopRequireDefault(_react);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+        function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+        function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /* eslint-disable react/prop-types */
+
+        var extendReactClass = undefined;
+
+        /**
+         * @param {ReactClass} Component
+         * @param {Object} defaultStyles
+         * @param {Object} options
+         * @returns {ReactClass}
+         */
+        extendReactClass = function (Component, defaultStyles, options) {
+            return (function (_Component) {
+                _inherits(_class, _Component);
+
+                function _class() {
+                    _classCallCheck(this, _class);
+
+                    return _possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+                }
+
+                _createClass(_class, [{
+                    key: 'render',
+                    value: function render() {
+                        var renderResult = undefined,
+                            styles = undefined;
+
+                        if (this.props.styles) {
+                            styles = this.props.styles;
+                        } else if ((0, _isObject2.default)(defaultStyles)) {
+                            this.props = (0, _assign2.default)({}, this.props, {
+                                styles: defaultStyles
+                            });
+
+                            styles = defaultStyles;
+                        } else {
+                            styles = {};
+                        }
+
+                        renderResult = _get(Object.getPrototypeOf(_class.prototype), 'render', this).call(this);
+
+                        if (renderResult) {
+                            return (0, _linkClass2.default)(renderResult, styles, options);
+                        }
+
+                        return _react2.default.createElement('noscript');
+                    }
+                }]);
+
+                return _class;
+            })(Component);
+        };
+
+        exports.default = extendReactClass;
+        //# sourceMappingURL=extendReactClass.js.map
+
+
+        /***/ },
+    /* 4 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var assignWith = __ReactCssModules_require__(5),
+            baseAssign = __ReactCssModules_require__(19),
+            createAssigner = __ReactCssModules_require__(21);
+
+        /**
+         * Assigns own enumerable properties of source object(s) to the destination
+         * object. Subsequent sources overwrite property assignments of previous sources.
+         * If `customizer` is provided it's invoked to produce the assigned values.
+         * The `customizer` is bound to `thisArg` and invoked with five arguments:
+         * (objectValue, sourceValue, key, object, source).
+         *
+         * **Note:** This method mutates `object` and is based on
+         * [`Object.assign`](http://ecma-international.org/ecma-262/6.0/#sec-object.assign).
+         *
+         * @static
+         * @memberOf _
+         * @alias extend
+         * @category Object
+         * @param {Object} object The destination object.
+         * @param {...Object} [sources] The source objects.
+         * @param {Function} [customizer] The function to customize assigned values.
+         * @param {*} [thisArg] The `this` binding of `customizer`.
+         * @returns {Object} Returns `object`.
+         * @example
+         *
+         * _.assign({ 'user': 'barney' }, { 'age': 40 }, { 'user': 'fred' });
+         * // => { 'user': 'fred', 'age': 40 }
+         *
+         * // using a customizer callback
+         * var defaults = _.partialRight(_.assign, function(value, other) {
+	 *   return _.isUndefined(value) ? other : value;
+	 * });
+         *
+         * defaults({ 'user': 'barney' }, { 'age': 36 }, { 'user': 'fred' });
+         * // => { 'user': 'barney', 'age': 36 }
+         */
+        var assign = createAssigner(function(object, source, customizer) {
+            return customizer
+                ? assignWith(object, source, customizer)
+                : baseAssign(object, source);
+        });
+
+        module.exports = assign;
+
+
+        /***/ },
+    /* 5 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var keys = __ReactCssModules_require__(6);
+
+        /**
+         * A specialized version of `_.assign` for customizing assigned values without
+         * support for argument juggling, multiple sources, and `this` binding `customizer`
+         * functions.
+         *
+         * @private
+         * @param {Object} object The destination object.
+         * @param {Object} source The source object.
+         * @param {Function} customizer The function to customize assigned values.
+         * @returns {Object} Returns `object`.
+         */
+        function assignWith(object, source, customizer) {
+            var index = -1,
+                props = keys(source),
+                length = props.length;
+
+            while (++index < length) {
+                var key = props[index],
+                    value = object[key],
+                    result = customizer(value, source[key], key, object, source);
+
+                if ((result === result ? (result !== value) : (value === value)) ||
+                    (value === undefined && !(key in object))) {
+                    object[key] = result;
+                }
+            }
+            return object;
+        }
+
+        module.exports = assignWith;
+
+
+        /***/ },
+    /* 6 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var getNative = __ReactCssModules_require__(7),
+            isArrayLike = __ReactCssModules_require__(10),
+            isObject = __ReactCssModules_require__(2),
+            shimKeys = __ReactCssModules_require__(14);
+
+        /* Native method references for those with the same name as other `lodash` methods. */
+        var nativeKeys = getNative(Object, 'keys');
+
+        /**
+         * Creates an array of the own enumerable property names of `object`.
+         *
+         * **Note:** Non-object values are coerced to objects. See the
+         * [ES spec](http://ecma-international.org/ecma-262/6.0/#sec-object.keys)
+         * for more details.
+         *
+         * @static
+         * @memberOf _
+         * @category Object
+         * @param {Object} object The object to query.
+         * @returns {Array} Returns the array of property names.
+         * @example
+         *
+         * function Foo() {
+	 *   this.a = 1;
+	 *   this.b = 2;
+	 * }
+         *
+         * Foo.prototype.c = 3;
+         *
+         * _.keys(new Foo);
+         * // => ['a', 'b'] (iteration order is not guaranteed)
+         *
+         * _.keys('hi');
+         * // => ['0', '1']
+         */
+        var keys = !nativeKeys ? shimKeys : function(object) {
+            var Ctor = object == null ? undefined : object.constructor;
+            if ((typeof Ctor == 'function' && Ctor.prototype === object) ||
+                (typeof object != 'function' && isArrayLike(object))) {
+                return shimKeys(object);
+            }
+            return isObject(object) ? nativeKeys(object) : [];
+        };
+
+        module.exports = keys;
+
+
+        /***/ },
+    /* 7 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isNative = __ReactCssModules_require__(8);
+
+        /**
+         * Gets the native function at `key` of `object`.
+         *
+         * @private
+         * @param {Object} object The object to query.
+         * @param {string} key The key of the method to get.
+         * @returns {*} Returns the function if it's native, else `undefined`.
+         */
+        function getNative(object, key) {
+            var value = object == null ? undefined : object[key];
+            return isNative(value) ? value : undefined;
+        }
+
+        module.exports = getNative;
+
+
+        /***/ },
+    /* 8 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isFunction = __ReactCssModules_require__(1),
+            isObjectLike = __ReactCssModules_require__(9);
+
+        /** Used to detect host constructors (Safari > 5). */
+        var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to resolve the decompiled source of functions. */
+        var fnToString = Function.prototype.toString;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /** Used to detect if a method is native. */
+        var reIsNative = RegExp('^' +
+                                fnToString.call(hasOwnProperty).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+                                    .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
+        );
+
+        /**
+         * Checks if `value` is a native function.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is a native function, else `false`.
+         * @example
+         *
+         * _.isNative(Array.prototype.push);
+         * // => true
+         *
+         * _.isNative(_);
+         * // => false
+         */
+        function isNative(value) {
+            if (value == null) {
+                return false;
+            }
+            if (isFunction(value)) {
+                return reIsNative.test(fnToString.call(value));
+            }
+            return isObjectLike(value) && reIsHostCtor.test(value);
+        }
+
+        module.exports = isNative;
+
+
+        /***/ },
+    /* 9 */
+    /***/ function(module, exports) {
+
+        /**
+         * Checks if `value` is object-like.
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+         */
+        function isObjectLike(value) {
+            return !!value && typeof value == 'object';
+        }
+
+        module.exports = isObjectLike;
+
+
+        /***/ },
+    /* 10 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var getLength = __ReactCssModules_require__(11),
+            isLength = __ReactCssModules_require__(13);
+
+        /**
+         * Checks if `value` is array-like.
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
+         */
+        function isArrayLike(value) {
+            return value != null && isLength(getLength(value));
+        }
+
+        module.exports = isArrayLike;
+
+
+        /***/ },
+    /* 11 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseProperty = __ReactCssModules_require__(12);
+
+        /**
+         * Gets the "length" property value of `object`.
+         *
+         * **Note:** This function is used to avoid a [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792)
+         * that affects Safari on at least iOS 8.1-8.3 ARM64.
+         *
+         * @private
+         * @param {Object} object The object to query.
+         * @returns {*} Returns the "length" value.
+         */
+        var getLength = baseProperty('length');
+
+        module.exports = getLength;
+
+
+        /***/ },
+    /* 12 */
+    /***/ function(module, exports) {
+
+        /**
+         * The base implementation of `_.property` without support for deep paths.
+         *
+         * @private
+         * @param {string} key The key of the property to get.
+         * @returns {Function} Returns the new function.
+         */
+        function baseProperty(key) {
+            return function(object) {
+                return object == null ? undefined : object[key];
+            };
+        }
+
+        module.exports = baseProperty;
+
+
+        /***/ },
+    /* 13 */
+    /***/ function(module, exports) {
+
+        /**
+         * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
+         * of an array-like value.
+         */
+        var MAX_SAFE_INTEGER = 9007199254740991;
+
+        /**
+         * Checks if `value` is a valid array-like length.
+         *
+         * **Note:** This function is based on [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+         */
+        function isLength(value) {
+            return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+        }
+
+        module.exports = isLength;
+
+
+        /***/ },
+    /* 14 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isArguments = __ReactCssModules_require__(15),
+            isArray = __ReactCssModules_require__(16),
+            isIndex = __ReactCssModules_require__(17),
+            isLength = __ReactCssModules_require__(13),
+            keysIn = __ReactCssModules_require__(18);
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /**
+         * A fallback implementation of `Object.keys` which creates an array of the
+         * own enumerable property names of `object`.
+         *
+         * @private
+         * @param {Object} object The object to query.
+         * @returns {Array} Returns the array of property names.
+         */
+        function shimKeys(object) {
+            var props = keysIn(object),
+                propsLength = props.length,
+                length = propsLength && object.length;
+
+            var allowIndexes = !!length && isLength(length) &&
+                               (isArray(object) || isArguments(object));
+
+            var index = -1,
+                result = [];
+
+            while (++index < propsLength) {
+                var key = props[index];
+                if ((allowIndexes && isIndex(key, length)) || hasOwnProperty.call(object, key)) {
+                    result.push(key);
+                }
+            }
+            return result;
+        }
+
+        module.exports = shimKeys;
+
+
+        /***/ },
+    /* 15 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isArrayLike = __ReactCssModules_require__(10),
+            isObjectLike = __ReactCssModules_require__(9);
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /** Native method references. */
+        var propertyIsEnumerable = objectProto.propertyIsEnumerable;
+
+        /**
+         * Checks if `value` is classified as an `arguments` object.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+         * @example
+         *
+         * _.isArguments(function() { return arguments; }());
+         * // => true
+         *
+         * _.isArguments([1, 2, 3]);
+         * // => false
+         */
+        function isArguments(value) {
+            return isObjectLike(value) && isArrayLike(value) &&
+                   hasOwnProperty.call(value, 'callee') && !propertyIsEnumerable.call(value, 'callee');
+        }
+
+        module.exports = isArguments;
+
+
+        /***/ },
+    /* 16 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var getNative = __ReactCssModules_require__(7),
+            isLength = __ReactCssModules_require__(13),
+            isObjectLike = __ReactCssModules_require__(9);
+
+        /** `Object#toString` result references. */
+        var arrayTag = '[object Array]';
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /**
+         * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+         * of values.
+         */
+        var objToString = objectProto.toString;
+
+        /* Native method references for those with the same name as other `lodash` methods. */
+        var nativeIsArray = getNative(Array, 'isArray');
+
+        /**
+         * Checks if `value` is classified as an `Array` object.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+         * @example
+         *
+         * _.isArray([1, 2, 3]);
+         * // => true
+         *
+         * _.isArray(function() { return arguments; }());
+         * // => false
+         */
+        var isArray = nativeIsArray || function(value) {
+                return isObjectLike(value) && isLength(value.length) && objToString.call(value) == arrayTag;
+            };
+
+        module.exports = isArray;
+
+
+        /***/ },
+    /* 17 */
+    /***/ function(module, exports) {
+
+        /** Used to detect unsigned integer values. */
+        var reIsUint = /^\d+$/;
+
+        /**
+         * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
+         * of an array-like value.
+         */
+        var MAX_SAFE_INTEGER = 9007199254740991;
+
+        /**
+         * Checks if `value` is a valid array-like index.
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+         * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+         */
+        function isIndex(value, length) {
+            value = (typeof value == 'number' || reIsUint.test(value)) ? +value : -1;
+            length = length == null ? MAX_SAFE_INTEGER : length;
+            return value > -1 && value % 1 == 0 && value < length;
+        }
+
+        module.exports = isIndex;
+
+
+        /***/ },
+    /* 18 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isArguments = __ReactCssModules_require__(15),
+            isArray = __ReactCssModules_require__(16),
+            isIndex = __ReactCssModules_require__(17),
+            isLength = __ReactCssModules_require__(13),
+            isObject = __ReactCssModules_require__(2);
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /**
+         * Creates an array of the own and inherited enumerable property names of `object`.
+         *
+         * **Note:** Non-object values are coerced to objects.
+         *
+         * @static
+         * @memberOf _
+         * @category Object
+         * @param {Object} object The object to query.
+         * @returns {Array} Returns the array of property names.
+         * @example
+         *
+         * function Foo() {
+	 *   this.a = 1;
+	 *   this.b = 2;
+	 * }
+         *
+         * Foo.prototype.c = 3;
+         *
+         * _.keysIn(new Foo);
+         * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
+         */
+        function keysIn(object) {
+            if (object == null) {
+                return [];
+            }
+            if (!isObject(object)) {
+                object = Object(object);
+            }
+            var length = object.length;
+            length = (length && isLength(length) &&
+                      (isArray(object) || isArguments(object)) && length) || 0;
+
+            var Ctor = object.constructor,
+                index = -1,
+                isProto = typeof Ctor == 'function' && Ctor.prototype === object,
+                result = Array(length),
+                skipIndexes = length > 0;
+
+            while (++index < length) {
+                result[index] = (index + '');
+            }
+            for (var key in object) {
+                if (!(skipIndexes && isIndex(key, length)) &&
+                    !(key == 'constructor' && (isProto || !hasOwnProperty.call(object, key)))) {
+                    result.push(key);
+                }
+            }
+            return result;
+        }
+
+        module.exports = keysIn;
+
+
+        /***/ },
+    /* 19 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseCopy = __ReactCssModules_require__(20),
+            keys = __ReactCssModules_require__(6);
+
+        /**
+         * The base implementation of `_.assign` without support for argument juggling,
+         * multiple sources, and `customizer` functions.
+         *
+         * @private
+         * @param {Object} object The destination object.
+         * @param {Object} source The source object.
+         * @returns {Object} Returns `object`.
+         */
+        function baseAssign(object, source) {
+            return source == null
+                ? object
+                : baseCopy(source, keys(source), object);
+        }
+
+        module.exports = baseAssign;
+
+
+        /***/ },
+    /* 20 */
+    /***/ function(module, exports) {
+
+        /**
+         * Copies properties of `source` to `object`.
+         *
+         * @private
+         * @param {Object} source The object to copy properties from.
+         * @param {Array} props The property names to copy.
+         * @param {Object} [object={}] The object to copy properties to.
+         * @returns {Object} Returns `object`.
+         */
+        function baseCopy(source, props, object) {
+            object || (object = {});
+
+            var index = -1,
+                length = props.length;
+
+            while (++index < length) {
+                var key = props[index];
+                object[key] = source[key];
+            }
+            return object;
+        }
+
+        module.exports = baseCopy;
+
+
+        /***/ },
+    /* 21 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var bindCallback = __ReactCssModules_require__(22),
+            isIterateeCall = __ReactCssModules_require__(24),
+            restParam = __ReactCssModules_require__(25);
+
+        /**
+         * Creates a `_.assign`, `_.defaults`, or `_.merge` function.
+         *
+         * @private
+         * @param {Function} assigner The function to assign values.
+         * @returns {Function} Returns the new assigner function.
+         */
+        function createAssigner(assigner) {
+            return restParam(function(object, sources) {
+                var index = -1,
+                    length = object == null ? 0 : sources.length,
+                    customizer = length > 2 ? sources[length - 2] : undefined,
+                    guard = length > 2 ? sources[2] : undefined,
+                    thisArg = length > 1 ? sources[length - 1] : undefined;
+
+                if (typeof customizer == 'function') {
+                    customizer = bindCallback(customizer, thisArg, 5);
+                    length -= 2;
+                } else {
+                    customizer = typeof thisArg == 'function' ? thisArg : undefined;
+                    length -= (customizer ? 1 : 0);
+                }
+                if (guard && isIterateeCall(sources[0], sources[1], guard)) {
+                    customizer = length < 3 ? undefined : customizer;
+                    length = 1;
+                }
+                while (++index < length) {
+                    var source = sources[index];
+                    if (source) {
+                        assigner(object, source, customizer);
+                    }
+                }
+                return object;
+            });
+        }
+
+        module.exports = createAssigner;
+
+
+        /***/ },
+    /* 22 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var identity = __ReactCssModules_require__(23);
+
+        /**
+         * A specialized version of `baseCallback` which only supports `this` binding
+         * and specifying the number of arguments to provide to `func`.
+         *
+         * @private
+         * @param {Function} func The function to bind.
+         * @param {*} thisArg The `this` binding of `func`.
+         * @param {number} [argCount] The number of arguments to provide to `func`.
+         * @returns {Function} Returns the callback.
+         */
+        function bindCallback(func, thisArg, argCount) {
+            if (typeof func != 'function') {
+                return identity;
+            }
+            if (thisArg === undefined) {
+                return func;
+            }
+            switch (argCount) {
+                case 1: return function(value) {
+                    return func.call(thisArg, value);
+                };
+                case 3: return function(value, index, collection) {
+                    return func.call(thisArg, value, index, collection);
+                };
+                case 4: return function(accumulator, value, index, collection) {
+                    return func.call(thisArg, accumulator, value, index, collection);
+                };
+                case 5: return function(value, other, key, object, source) {
+                    return func.call(thisArg, value, other, key, object, source);
+                };
+            }
+            return function() {
+                return func.apply(thisArg, arguments);
+            };
+        }
+
+        module.exports = bindCallback;
+
+
+        /***/ },
+    /* 23 */
+    /***/ function(module, exports) {
+
+        /**
+         * This method returns the first argument provided to it.
+         *
+         * @static
+         * @memberOf _
+         * @category Utility
+         * @param {*} value Any value.
+         * @returns {*} Returns `value`.
+         * @example
+         *
+         * var object = { 'user': 'fred' };
+         *
+         * _.identity(object) === object;
+         * // => true
+         */
+        function identity(value) {
+            return value;
+        }
+
+        module.exports = identity;
+
+
+        /***/ },
+    /* 24 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isArrayLike = __ReactCssModules_require__(10),
+            isIndex = __ReactCssModules_require__(17),
+            isObject = __ReactCssModules_require__(2);
+
+        /**
+         * Checks if the provided arguments are from an iteratee call.
+         *
+         * @private
+         * @param {*} value The potential iteratee value argument.
+         * @param {*} index The potential iteratee index or key argument.
+         * @param {*} object The potential iteratee object argument.
+         * @returns {boolean} Returns `true` if the arguments are from an iteratee call, else `false`.
+         */
+        function isIterateeCall(value, index, object) {
+            if (!isObject(object)) {
+                return false;
+            }
+            var type = typeof index;
+            if (type == 'number'
+                    ? (isArrayLike(object) && isIndex(index, object.length))
+                    : (type == 'string' && index in object)) {
+                var other = object[index];
+                return value === value ? (value === other) : (other !== other);
+            }
+            return false;
+        }
+
+        module.exports = isIterateeCall;
+
+
+        /***/ },
+    /* 25 */
+    /***/ function(module, exports) {
+
+        /** Used as the `TypeError` message for "Functions" methods. */
+        var FUNC_ERROR_TEXT = 'Expected a function';
+
+        /* Native method references for those with the same name as other `lodash` methods. */
+        var nativeMax = Math.max;
+
+        /**
+         * Creates a function that invokes `func` with the `this` binding of the
+         * created function and arguments from `start` and beyond provided as an array.
+         *
+         * **Note:** This method is based on the [rest parameter](https://developer.mozilla.org/Web/JavaScript/Reference/Functions/rest_parameters).
+         *
+         * @static
+         * @memberOf _
+         * @category Function
+         * @param {Function} func The function to apply a rest parameter to.
+         * @param {number} [start=func.length-1] The start position of the rest parameter.
+         * @returns {Function} Returns the new function.
+         * @example
+         *
+         * var say = _.restParam(function(what, names) {
+	 *   return what + ' ' + _.initial(names).join(', ') +
+	 *     (_.size(names) > 1 ? ', & ' : '') + _.last(names);
+	 * });
+         *
+         * say('hello', 'fred', 'barney', 'pebbles');
+         * // => 'hello fred, barney, & pebbles'
+         */
+        function restParam(func, start) {
+            if (typeof func != 'function') {
+                throw new TypeError(FUNC_ERROR_TEXT);
+            }
+            start = nativeMax(start === undefined ? (func.length - 1) : (+start || 0), 0);
+            return function() {
+                var args = arguments,
+                    index = -1,
+                    length = nativeMax(args.length - start, 0),
+                    rest = Array(length);
+
+                while (++index < length) {
+                    rest[index] = args[start + index];
+                }
+                switch (start) {
+                    case 0: return func.call(this, rest);
+                    case 1: return func.call(this, args[0], rest);
+                    case 2: return func.call(this, args[0], args[1], rest);
+                }
+                var otherArgs = Array(start + 1);
+                index = -1;
+                while (++index < start) {
+                    otherArgs[index] = args[index];
+                }
+                otherArgs[start] = rest;
+                return func.apply(this, otherArgs);
+            };
+        }
+
+        module.exports = restParam;
+
+
+        /***/ },
+    /* 26 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _isArray = __ReactCssModules_require__(16);
+
+        var _isArray2 = _interopRequireDefault(_isArray);
+
+        var _map = __ReactCssModules_require__(27);
+
+        var _map2 = _interopRequireDefault(_map);
+
+        var _filter = __ReactCssModules_require__(58);
+
+        var _filter2 = _interopRequireDefault(_filter);
+
+        var _react = __ReactCssModules_require__(61);
+
+        var _react2 = _interopRequireDefault(_react);
+
+        var _makeConfiguration = __ReactCssModules_require__(62);
+
+        var _makeConfiguration2 = _interopRequireDefault(_makeConfiguration);
+
+        var _isIterable = __ReactCssModules_require__(68);
+
+        var _isIterable2 = _interopRequireDefault(_isIterable);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        var linkClass = undefined;
+
+        /**
+         * @param {ReactElement} element
+         * @param {Object} styles CSS modules class map.
+         * @param {CSSModules~Options} userConfiguration
+         * @return {ReactElement}
+         */
+        linkClass = function (element) {
+            var styles = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+            var userConfiguration = arguments[2];
+
+            var appendClassName = undefined,
+                children = undefined,
+                clonedElement = undefined,
+                configuration = undefined,
+                newChildren = undefined,
+                newProps = undefined,
+                styleNames = undefined;
+
+            // @see https://github.com/gajus/react-css-modules/pull/30
+            if (!element) {
+                return element;
+            }
+
+            configuration = (0, _makeConfiguration2.default)(userConfiguration);
+
+            styleNames = element.props.styleName;
+
+            if (styleNames) {
+                styleNames = styleNames.split(' ');
+                styleNames = (0, _filter2.default)(styleNames);
+
+                if (configuration.allowMultiple === false && styleNames.length > 1) {
+                    throw new Error('ReactElement styleName property defines multiple module names ("' + element.props.styleName + '").');
+                }
+
+                appendClassName = (0, _map2.default)(styleNames, function (styleName) {
+                    if (styles[styleName]) {
+                        return styles[styleName];
+                    } else {
+                        if (configuration.errorWhenNotFound === true) {
+                            throw new Error('"' + styleName + '" CSS module is undefined.');
+                        }
+
+                        return '';
+                    }
+                });
+
+                appendClassName = (0, _filter2.default)(appendClassName, 'length');
+
+                appendClassName = appendClassName.join(' ');
+            }
+
+            // element.props.children can be one of the following:
+            // 'text'
+            // ['text']
+            // [ReactElement, 'text']
+            // ReactElement
+
+            children = element.props.children;
+
+            if (_react2.default.isValidElement(children)) {
+                newChildren = linkClass(_react2.default.Children.only(children), styles, configuration);
+            } else if ((0, _isArray2.default)(children) || (0, _isIterable2.default)(children)) {
+                /* eslint-disable lodash3/prefer-lodash-method */
+                newChildren = _react2.default.Children.map(children, function (node) {
+                    /* eslint-enable lodash3/prefer-lodash-method */
+                    if (_react2.default.isValidElement(node)) {
+                        return linkClass(node, styles, configuration);
+                    } else {
+                        return node;
+                    }
+                });
+
+                // https://github.com/facebook/react/issues/4723#issuecomment-135555277
+                // Forcing children into an array produces the following error:
+                // Warning: A ReactFragment is an opaque type. Accessing any of its properties is deprecated. Pass it to one of the React.Children helpers.
+                // newChildren = _.values(newChildren);
+            }
+
+            if (appendClassName) {
+                if (element.props.className) {
+                    appendClassName = element.props.className + ' ' + appendClassName;
+                }
+
+                newProps = {
+                    className: appendClassName
+                };
+            }
+
+            if (newChildren) {
+                clonedElement = _react2.default.cloneElement(element, newProps, newChildren);
+            } else {
+                clonedElement = _react2.default.cloneElement(element, newProps);
+            }
+
+            return clonedElement;
+        };
+
+        exports.default = linkClass;
+        //# sourceMappingURL=linkClass.js.map
+
+
+        /***/ },
+    /* 27 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var arrayMap = __ReactCssModules_require__(28),
+            baseCallback = __ReactCssModules_require__(29),
+            baseMap = __ReactCssModules_require__(52),
+            isArray = __ReactCssModules_require__(16);
+
+        /**
+         * Creates an array of values by running each element in `collection` through
+         * `iteratee`. The `iteratee` is bound to `thisArg` and invoked with three
+         * arguments: (value, index|key, collection).
+         *
+         * If a property name is provided for `iteratee` the created `_.property`
+         * style callback returns the property value of the given element.
+         *
+         * If a value is also provided for `thisArg` the created `_.matchesProperty`
+         * style callback returns `true` for elements that have a matching property
+         * value, else `false`.
+         *
+         * If an object is provided for `iteratee` the created `_.matches` style
+         * callback returns `true` for elements that have the properties of the given
+         * object, else `false`.
+         *
+         * Many lodash methods are guarded to work as iteratees for methods like
+         * `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
+         *
+         * The guarded methods are:
+         * `ary`, `callback`, `chunk`, `clone`, `create`, `curry`, `curryRight`,
+         * `drop`, `dropRight`, `every`, `fill`, `flatten`, `invert`, `max`, `min`,
+         * `parseInt`, `slice`, `sortBy`, `take`, `takeRight`, `template`, `trim`,
+         * `trimLeft`, `trimRight`, `trunc`, `random`, `range`, `sample`, `some`,
+         * `sum`, `uniq`, and `words`
+         *
+         * @static
+         * @memberOf _
+         * @alias collect
+         * @category Collection
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function|Object|string} [iteratee=_.identity] The function invoked
+         *  per iteration.
+         * @param {*} [thisArg] The `this` binding of `iteratee`.
+         * @returns {Array} Returns the new mapped array.
+         * @example
+         *
+         * function timesThree(n) {
+	 *   return n * 3;
+	 * }
+         *
+         * _.map([1, 2], timesThree);
+         * // => [3, 6]
+         *
+         * _.map({ 'a': 1, 'b': 2 }, timesThree);
+         * // => [3, 6] (iteration order is not guaranteed)
+         *
+         * var users = [
+         *   { 'user': 'barney' },
+         *   { 'user': 'fred' }
+         * ];
+         *
+         * // using the `_.property` callback shorthand
+         * _.map(users, 'user');
+         * // => ['barney', 'fred']
+         */
+        function map(collection, iteratee, thisArg) {
+            var func = isArray(collection) ? arrayMap : baseMap;
+            iteratee = baseCallback(iteratee, thisArg, 3);
+            return func(collection, iteratee);
+        }
+
+        module.exports = map;
+
+
+        /***/ },
+    /* 28 */
+    /***/ function(module, exports) {
+
+        /**
+         * A specialized version of `_.map` for arrays without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array} array The array to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @returns {Array} Returns the new mapped array.
+         */
+        function arrayMap(array, iteratee) {
+            var index = -1,
+                length = array.length,
+                result = Array(length);
+
+            while (++index < length) {
+                result[index] = iteratee(array[index], index, array);
+            }
+            return result;
+        }
+
+        module.exports = arrayMap;
+
+
+        /***/ },
+    /* 29 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseMatches = __ReactCssModules_require__(30),
+            baseMatchesProperty = __ReactCssModules_require__(43),
+            bindCallback = __ReactCssModules_require__(22),
+            identity = __ReactCssModules_require__(23),
+            property = __ReactCssModules_require__(50);
+
+        /**
+         * The base implementation of `_.callback` which supports specifying the
+         * number of arguments to provide to `func`.
+         *
+         * @private
+         * @param {*} [func=_.identity] The value to convert to a callback.
+         * @param {*} [thisArg] The `this` binding of `func`.
+         * @param {number} [argCount] The number of arguments to provide to `func`.
+         * @returns {Function} Returns the callback.
+         */
+        function baseCallback(func, thisArg, argCount) {
+            var type = typeof func;
+            if (type == 'function') {
+                return thisArg === undefined
+                    ? func
+                    : bindCallback(func, thisArg, argCount);
+            }
+            if (func == null) {
+                return identity;
+            }
+            if (type == 'object') {
+                return baseMatches(func);
+            }
+            return thisArg === undefined
+                ? property(func)
+                : baseMatchesProperty(func, thisArg);
+        }
+
+        module.exports = baseCallback;
+
+
+        /***/ },
+    /* 30 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseIsMatch = __ReactCssModules_require__(31),
+            getMatchData = __ReactCssModules_require__(40),
+            toObject = __ReactCssModules_require__(39);
+
+        /**
+         * The base implementation of `_.matches` which does not clone `source`.
+         *
+         * @private
+         * @param {Object} source The object of property values to match.
+         * @returns {Function} Returns the new function.
+         */
+        function baseMatches(source) {
+            var matchData = getMatchData(source);
+            if (matchData.length == 1 && matchData[0][2]) {
+                var key = matchData[0][0],
+                    value = matchData[0][1];
+
+                return function(object) {
+                    if (object == null) {
+                        return false;
+                    }
+                    return object[key] === value && (value !== undefined || (key in toObject(object)));
+                };
+            }
+            return function(object) {
+                return baseIsMatch(object, matchData);
+            };
+        }
+
+        module.exports = baseMatches;
+
+
+        /***/ },
+    /* 31 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseIsEqual = __ReactCssModules_require__(32),
+            toObject = __ReactCssModules_require__(39);
+
+        /**
+         * The base implementation of `_.isMatch` without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Object} object The object to inspect.
+         * @param {Array} matchData The propery names, values, and compare flags to match.
+         * @param {Function} [customizer] The function to customize comparing objects.
+         * @returns {boolean} Returns `true` if `object` is a match, else `false`.
+         */
+        function baseIsMatch(object, matchData, customizer) {
+            var index = matchData.length,
+                length = index,
+                noCustomizer = !customizer;
+
+            if (object == null) {
+                return !length;
+            }
+            object = toObject(object);
+            while (index--) {
+                var data = matchData[index];
+                if ((noCustomizer && data[2])
+                        ? data[1] !== object[data[0]]
+                        : !(data[0] in object)
+                ) {
+                    return false;
+                }
+            }
+            while (++index < length) {
+                data = matchData[index];
+                var key = data[0],
+                    objValue = object[key],
+                    srcValue = data[1];
+
+                if (noCustomizer && data[2]) {
+                    if (objValue === undefined && !(key in object)) {
+                        return false;
+                    }
+                } else {
+                    var result = customizer ? customizer(objValue, srcValue, key) : undefined;
+                    if (!(result === undefined ? baseIsEqual(srcValue, objValue, customizer, true) : result)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        module.exports = baseIsMatch;
+
+
+        /***/ },
+    /* 32 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseIsEqualDeep = __ReactCssModules_require__(33),
+            isObject = __ReactCssModules_require__(2),
+            isObjectLike = __ReactCssModules_require__(9);
+
+        /**
+         * The base implementation of `_.isEqual` without support for `this` binding
+         * `customizer` functions.
+         *
+         * @private
+         * @param {*} value The value to compare.
+         * @param {*} other The other value to compare.
+         * @param {Function} [customizer] The function to customize comparing values.
+         * @param {boolean} [isLoose] Specify performing partial comparisons.
+         * @param {Array} [stackA] Tracks traversed `value` objects.
+         * @param {Array} [stackB] Tracks traversed `other` objects.
+         * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+         */
+        function baseIsEqual(value, other, customizer, isLoose, stackA, stackB) {
+            if (value === other) {
+                return true;
+            }
+            if (value == null || other == null || (!isObject(value) && !isObjectLike(other))) {
+                return value !== value && other !== other;
+            }
+            return baseIsEqualDeep(value, other, baseIsEqual, customizer, isLoose, stackA, stackB);
+        }
+
+        module.exports = baseIsEqual;
+
+
+        /***/ },
+    /* 33 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var equalArrays = __ReactCssModules_require__(34),
+            equalByTag = __ReactCssModules_require__(36),
+            equalObjects = __ReactCssModules_require__(37),
+            isArray = __ReactCssModules_require__(16),
+            isTypedArray = __ReactCssModules_require__(38);
+
+        /** `Object#toString` result references. */
+        var argsTag = '[object Arguments]',
+            arrayTag = '[object Array]',
+            objectTag = '[object Object]';
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /**
+         * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+         * of values.
+         */
+        var objToString = objectProto.toString;
+
+        /**
+         * A specialized version of `baseIsEqual` for arrays and objects which performs
+         * deep comparisons and tracks traversed objects enabling objects with circular
+         * references to be compared.
+         *
+         * @private
+         * @param {Object} object The object to compare.
+         * @param {Object} other The other object to compare.
+         * @param {Function} equalFunc The function to determine equivalents of values.
+         * @param {Function} [customizer] The function to customize comparing objects.
+         * @param {boolean} [isLoose] Specify performing partial comparisons.
+         * @param {Array} [stackA=[]] Tracks traversed `value` objects.
+         * @param {Array} [stackB=[]] Tracks traversed `other` objects.
+         * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+         */
+        function baseIsEqualDeep(object, other, equalFunc, customizer, isLoose, stackA, stackB) {
+            var objIsArr = isArray(object),
+                othIsArr = isArray(other),
+                objTag = arrayTag,
+                othTag = arrayTag;
+
+            if (!objIsArr) {
+                objTag = objToString.call(object);
+                if (objTag == argsTag) {
+                    objTag = objectTag;
+                } else if (objTag != objectTag) {
+                    objIsArr = isTypedArray(object);
+                }
+            }
+            if (!othIsArr) {
+                othTag = objToString.call(other);
+                if (othTag == argsTag) {
+                    othTag = objectTag;
+                } else if (othTag != objectTag) {
+                    othIsArr = isTypedArray(other);
+                }
+            }
+            var objIsObj = objTag == objectTag,
+                othIsObj = othTag == objectTag,
+                isSameTag = objTag == othTag;
+
+            if (isSameTag && !(objIsArr || objIsObj)) {
+                return equalByTag(object, other, objTag);
+            }
+            if (!isLoose) {
+                var objIsWrapped = objIsObj && hasOwnProperty.call(object, '__wrapped__'),
+                    othIsWrapped = othIsObj && hasOwnProperty.call(other, '__wrapped__');
+
+                if (objIsWrapped || othIsWrapped) {
+                    return equalFunc(objIsWrapped ? object.value() : object, othIsWrapped ? other.value() : other, customizer, isLoose, stackA, stackB);
+                }
+            }
+            if (!isSameTag) {
+                return false;
+            }
+            // Assume cyclic values are equal.
+            // For more information on detecting circular references see https://es5.github.io/#JO.
+            stackA || (stackA = []);
+            stackB || (stackB = []);
+
+            var length = stackA.length;
+            while (length--) {
+                if (stackA[length] == object) {
+                    return stackB[length] == other;
+                }
+            }
+            // Add `object` and `other` to the stack of traversed objects.
+            stackA.push(object);
+            stackB.push(other);
+
+            var result = (objIsArr ? equalArrays : equalObjects)(object, other, equalFunc, customizer, isLoose, stackA, stackB);
+
+            stackA.pop();
+            stackB.pop();
+
+            return result;
+        }
+
+        module.exports = baseIsEqualDeep;
+
+
+        /***/ },
+    /* 34 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var arraySome = __ReactCssModules_require__(35);
+
+        /**
+         * A specialized version of `baseIsEqualDeep` for arrays with support for
+         * partial deep comparisons.
+         *
+         * @private
+         * @param {Array} array The array to compare.
+         * @param {Array} other The other array to compare.
+         * @param {Function} equalFunc The function to determine equivalents of values.
+         * @param {Function} [customizer] The function to customize comparing arrays.
+         * @param {boolean} [isLoose] Specify performing partial comparisons.
+         * @param {Array} [stackA] Tracks traversed `value` objects.
+         * @param {Array} [stackB] Tracks traversed `other` objects.
+         * @returns {boolean} Returns `true` if the arrays are equivalent, else `false`.
+         */
+        function equalArrays(array, other, equalFunc, customizer, isLoose, stackA, stackB) {
+            var index = -1,
+                arrLength = array.length,
+                othLength = other.length;
+
+            if (arrLength != othLength && !(isLoose && othLength > arrLength)) {
+                return false;
+            }
+            // Ignore non-index properties.
+            while (++index < arrLength) {
+                var arrValue = array[index],
+                    othValue = other[index],
+                    result = customizer ? customizer(isLoose ? othValue : arrValue, isLoose ? arrValue : othValue, index) : undefined;
+
+                if (result !== undefined) {
+                    if (result) {
+                        continue;
+                    }
+                    return false;
+                }
+                // Recursively compare arrays (susceptible to call stack limits).
+                if (isLoose) {
+                    if (!arraySome(other, function(othValue) {
+                            return arrValue === othValue || equalFunc(arrValue, othValue, customizer, isLoose, stackA, stackB);
+                        })) {
+                        return false;
+                    }
+                } else if (!(arrValue === othValue || equalFunc(arrValue, othValue, customizer, isLoose, stackA, stackB))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        module.exports = equalArrays;
+
+
+        /***/ },
+    /* 35 */
+    /***/ function(module, exports) {
+
+        /**
+         * A specialized version of `_.some` for arrays without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array} array The array to iterate over.
+         * @param {Function} predicate The function invoked per iteration.
+         * @returns {boolean} Returns `true` if any element passes the predicate check,
+         *  else `false`.
+         */
+        function arraySome(array, predicate) {
+            var index = -1,
+                length = array.length;
+
+            while (++index < length) {
+                if (predicate(array[index], index, array)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        module.exports = arraySome;
+
+
+        /***/ },
+    /* 36 */
+    /***/ function(module, exports) {
+
+        /** `Object#toString` result references. */
+        var boolTag = '[object Boolean]',
+            dateTag = '[object Date]',
+            errorTag = '[object Error]',
+            numberTag = '[object Number]',
+            regexpTag = '[object RegExp]',
+            stringTag = '[object String]';
+
+        /**
+         * A specialized version of `baseIsEqualDeep` for comparing objects of
+         * the same `toStringTag`.
+         *
+         * **Note:** This function only supports comparing values with tags of
+         * `Boolean`, `Date`, `Error`, `Number`, `RegExp`, or `String`.
+         *
+         * @private
+         * @param {Object} object The object to compare.
+         * @param {Object} other The other object to compare.
+         * @param {string} tag The `toStringTag` of the objects to compare.
+         * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+         */
+        function equalByTag(object, other, tag) {
+            switch (tag) {
+                case boolTag:
+                case dateTag:
+                    // Coerce dates and booleans to numbers, dates to milliseconds and booleans
+                    // to `1` or `0` treating invalid dates coerced to `NaN` as not equal.
+                    return +object == +other;
+
+                case errorTag:
+                    return object.name == other.name && object.message == other.message;
+
+                case numberTag:
+                    // Treat `NaN` vs. `NaN` as equal.
+                    return (object != +object)
+                        ? other != +other
+                        : object == +other;
+
+                case regexpTag:
+                case stringTag:
+                    // Coerce regexes to strings and treat strings primitives and string
+                    // objects as equal. See https://es5.github.io/#x15.10.6.4 for more details.
+                    return object == (other + '');
+            }
+            return false;
+        }
+
+        module.exports = equalByTag;
+
+
+        /***/ },
+    /* 37 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var keys = __ReactCssModules_require__(6);
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /** Used to check objects for own properties. */
+        var hasOwnProperty = objectProto.hasOwnProperty;
+
+        /**
+         * A specialized version of `baseIsEqualDeep` for objects with support for
+         * partial deep comparisons.
+         *
+         * @private
+         * @param {Object} object The object to compare.
+         * @param {Object} other The other object to compare.
+         * @param {Function} equalFunc The function to determine equivalents of values.
+         * @param {Function} [customizer] The function to customize comparing values.
+         * @param {boolean} [isLoose] Specify performing partial comparisons.
+         * @param {Array} [stackA] Tracks traversed `value` objects.
+         * @param {Array} [stackB] Tracks traversed `other` objects.
+         * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+         */
+        function equalObjects(object, other, equalFunc, customizer, isLoose, stackA, stackB) {
+            var objProps = keys(object),
+                objLength = objProps.length,
+                othProps = keys(other),
+                othLength = othProps.length;
+
+            if (objLength != othLength && !isLoose) {
+                return false;
+            }
+            var index = objLength;
+            while (index--) {
+                var key = objProps[index];
+                if (!(isLoose ? key in other : hasOwnProperty.call(other, key))) {
+                    return false;
+                }
+            }
+            var skipCtor = isLoose;
+            while (++index < objLength) {
+                key = objProps[index];
+                var objValue = object[key],
+                    othValue = other[key],
+                    result = customizer ? customizer(isLoose ? othValue : objValue, isLoose? objValue : othValue, key) : undefined;
+
+                // Recursively compare objects (susceptible to call stack limits).
+                if (!(result === undefined ? equalFunc(objValue, othValue, customizer, isLoose, stackA, stackB) : result)) {
+                    return false;
+                }
+                skipCtor || (skipCtor = key == 'constructor');
+            }
+            if (!skipCtor) {
+                var objCtor = object.constructor,
+                    othCtor = other.constructor;
+
+                // Non `Object` object instances with different constructors are not equal.
+                if (objCtor != othCtor &&
+                    ('constructor' in object && 'constructor' in other) &&
+                    !(typeof objCtor == 'function' && objCtor instanceof objCtor &&
+                    typeof othCtor == 'function' && othCtor instanceof othCtor)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        module.exports = equalObjects;
+
+
+        /***/ },
+    /* 38 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isLength = __ReactCssModules_require__(13),
+            isObjectLike = __ReactCssModules_require__(9);
+
+        /** `Object#toString` result references. */
+        var argsTag = '[object Arguments]',
+            arrayTag = '[object Array]',
+            boolTag = '[object Boolean]',
+            dateTag = '[object Date]',
+            errorTag = '[object Error]',
+            funcTag = '[object Function]',
+            mapTag = '[object Map]',
+            numberTag = '[object Number]',
+            objectTag = '[object Object]',
+            regexpTag = '[object RegExp]',
+            setTag = '[object Set]',
+            stringTag = '[object String]',
+            weakMapTag = '[object WeakMap]';
+
+        var arrayBufferTag = '[object ArrayBuffer]',
+            float32Tag = '[object Float32Array]',
+            float64Tag = '[object Float64Array]',
+            int8Tag = '[object Int8Array]',
+            int16Tag = '[object Int16Array]',
+            int32Tag = '[object Int32Array]',
+            uint8Tag = '[object Uint8Array]',
+            uint8ClampedTag = '[object Uint8ClampedArray]',
+            uint16Tag = '[object Uint16Array]',
+            uint32Tag = '[object Uint32Array]';
+
+        /** Used to identify `toStringTag` values of typed arrays. */
+        var typedArrayTags = {};
+        typedArrayTags[float32Tag] = typedArrayTags[float64Tag] =
+            typedArrayTags[int8Tag] = typedArrayTags[int16Tag] =
+                typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] =
+                    typedArrayTags[uint8ClampedTag] = typedArrayTags[uint16Tag] =
+                        typedArrayTags[uint32Tag] = true;
+        typedArrayTags[argsTag] = typedArrayTags[arrayTag] =
+            typedArrayTags[arrayBufferTag] = typedArrayTags[boolTag] =
+                typedArrayTags[dateTag] = typedArrayTags[errorTag] =
+                    typedArrayTags[funcTag] = typedArrayTags[mapTag] =
+                        typedArrayTags[numberTag] = typedArrayTags[objectTag] =
+                            typedArrayTags[regexpTag] = typedArrayTags[setTag] =
+                                typedArrayTags[stringTag] = typedArrayTags[weakMapTag] = false;
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /**
+         * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+         * of values.
+         */
+        var objToString = objectProto.toString;
+
+        /**
+         * Checks if `value` is classified as a typed array.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+         * @example
+         *
+         * _.isTypedArray(new Uint8Array);
+         * // => true
+         *
+         * _.isTypedArray([]);
+         * // => false
+         */
+        function isTypedArray(value) {
+            return isObjectLike(value) && isLength(value.length) && !!typedArrayTags[objToString.call(value)];
+        }
+
+        module.exports = isTypedArray;
+
+
+        /***/ },
+    /* 39 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isObject = __ReactCssModules_require__(2);
+
+        /**
+         * Converts `value` to an object if it's not one.
+         *
+         * @private
+         * @param {*} value The value to process.
+         * @returns {Object} Returns the object.
+         */
+        function toObject(value) {
+            return isObject(value) ? value : Object(value);
+        }
+
+        module.exports = toObject;
+
+
+        /***/ },
+    /* 40 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isStrictComparable = __ReactCssModules_require__(41),
+            pairs = __ReactCssModules_require__(42);
+
+        /**
+         * Gets the propery names, values, and compare flags of `object`.
+         *
+         * @private
+         * @param {Object} object The object to query.
+         * @returns {Array} Returns the match data of `object`.
+         */
+        function getMatchData(object) {
+            var result = pairs(object),
+                length = result.length;
+
+            while (length--) {
+                result[length][2] = isStrictComparable(result[length][1]);
+            }
+            return result;
+        }
+
+        module.exports = getMatchData;
+
+
+        /***/ },
+    /* 41 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isObject = __ReactCssModules_require__(2);
+
+        /**
+         * Checks if `value` is suitable for strict equality comparisons, i.e. `===`.
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` if suitable for strict
+         *  equality comparisons, else `false`.
+         */
+        function isStrictComparable(value) {
+            return value === value && !isObject(value);
+        }
+
+        module.exports = isStrictComparable;
+
+
+        /***/ },
+    /* 42 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var keys = __ReactCssModules_require__(6),
+            toObject = __ReactCssModules_require__(39);
+
+        /**
+         * Creates a two dimensional array of the key-value pairs for `object`,
+         * e.g. `[[key1, value1], [key2, value2]]`.
+         *
+         * @static
+         * @memberOf _
+         * @category Object
+         * @param {Object} object The object to query.
+         * @returns {Array} Returns the new array of key-value pairs.
+         * @example
+         *
+         * _.pairs({ 'barney': 36, 'fred': 40 });
+         * // => [['barney', 36], ['fred', 40]] (iteration order is not guaranteed)
+         */
+        function pairs(object) {
+            object = toObject(object);
+
+            var index = -1,
+                props = keys(object),
+                length = props.length,
+                result = Array(length);
+
+            while (++index < length) {
+                var key = props[index];
+                result[index] = [key, object[key]];
+            }
+            return result;
+        }
+
+        module.exports = pairs;
+
+
+        /***/ },
+    /* 43 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseGet = __ReactCssModules_require__(44),
+            baseIsEqual = __ReactCssModules_require__(32),
+            baseSlice = __ReactCssModules_require__(45),
+            isArray = __ReactCssModules_require__(16),
+            isKey = __ReactCssModules_require__(46),
+            isStrictComparable = __ReactCssModules_require__(41),
+            last = __ReactCssModules_require__(47),
+            toObject = __ReactCssModules_require__(39),
+            toPath = __ReactCssModules_require__(48);
+
+        /**
+         * The base implementation of `_.matchesProperty` which does not clone `srcValue`.
+         *
+         * @private
+         * @param {string} path The path of the property to get.
+         * @param {*} srcValue The value to compare.
+         * @returns {Function} Returns the new function.
+         */
+        function baseMatchesProperty(path, srcValue) {
+            var isArr = isArray(path),
+                isCommon = isKey(path) && isStrictComparable(srcValue),
+                pathKey = (path + '');
+
+            path = toPath(path);
+            return function(object) {
+                if (object == null) {
+                    return false;
+                }
+                var key = pathKey;
+                object = toObject(object);
+                if ((isArr || !isCommon) && !(key in object)) {
+                    object = path.length == 1 ? object : baseGet(object, baseSlice(path, 0, -1));
+                    if (object == null) {
+                        return false;
+                    }
+                    key = last(path);
+                    object = toObject(object);
+                }
+                return object[key] === srcValue
+                    ? (srcValue !== undefined || (key in object))
+                    : baseIsEqual(srcValue, object[key], undefined, true);
+            };
+        }
+
+        module.exports = baseMatchesProperty;
+
+
+        /***/ },
+    /* 44 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var toObject = __ReactCssModules_require__(39);
+
+        /**
+         * The base implementation of `get` without support for string paths
+         * and default values.
+         *
+         * @private
+         * @param {Object} object The object to query.
+         * @param {Array} path The path of the property to get.
+         * @param {string} [pathKey] The key representation of path.
+         * @returns {*} Returns the resolved value.
+         */
+        function baseGet(object, path, pathKey) {
+            if (object == null) {
+                return;
+            }
+            if (pathKey !== undefined && pathKey in toObject(object)) {
+                path = [pathKey];
+            }
+            var index = 0,
+                length = path.length;
+
+            while (object != null && index < length) {
+                object = object[path[index++]];
+            }
+            return (index && index == length) ? object : undefined;
+        }
+
+        module.exports = baseGet;
+
+
+        /***/ },
+    /* 45 */
+    /***/ function(module, exports) {
+
+        /**
+         * The base implementation of `_.slice` without an iteratee call guard.
+         *
+         * @private
+         * @param {Array} array The array to slice.
+         * @param {number} [start=0] The start position.
+         * @param {number} [end=array.length] The end position.
+         * @returns {Array} Returns the slice of `array`.
+         */
+        function baseSlice(array, start, end) {
+            var index = -1,
+                length = array.length;
+
+            start = start == null ? 0 : (+start || 0);
+            if (start < 0) {
+                start = -start > length ? 0 : (length + start);
+            }
+            end = (end === undefined || end > length) ? length : (+end || 0);
+            if (end < 0) {
+                end += length;
+            }
+            length = start > end ? 0 : ((end - start) >>> 0);
+            start >>>= 0;
+
+            var result = Array(length);
+            while (++index < length) {
+                result[index] = array[index + start];
+            }
+            return result;
+        }
+
+        module.exports = baseSlice;
+
+
+        /***/ },
+    /* 46 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isArray = __ReactCssModules_require__(16),
+            toObject = __ReactCssModules_require__(39);
+
+        /** Used to match property names within property paths. */
+        var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\n\\]|\\.)*?\1)\]/,
+            reIsPlainProp = /^\w*$/;
+
+        /**
+         * Checks if `value` is a property name and not a property path.
+         *
+         * @private
+         * @param {*} value The value to check.
+         * @param {Object} [object] The object to query keys on.
+         * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
+         */
+        function isKey(value, object) {
+            var type = typeof value;
+            if ((type == 'string' && reIsPlainProp.test(value)) || type == 'number') {
+                return true;
+            }
+            if (isArray(value)) {
+                return false;
+            }
+            var result = !reIsDeepProp.test(value);
+            return result || (object != null && value in toObject(object));
+        }
+
+        module.exports = isKey;
+
+
+        /***/ },
+    /* 47 */
+    /***/ function(module, exports) {
+
+        /**
+         * Gets the last element of `array`.
+         *
+         * @static
+         * @memberOf _
+         * @category Array
+         * @param {Array} array The array to query.
+         * @returns {*} Returns the last element of `array`.
+         * @example
+         *
+         * _.last([1, 2, 3]);
+         * // => 3
+         */
+        function last(array) {
+            var length = array ? array.length : 0;
+            return length ? array[length - 1] : undefined;
+        }
+
+        module.exports = last;
+
+
+        /***/ },
+    /* 48 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseToString = __ReactCssModules_require__(49),
+            isArray = __ReactCssModules_require__(16);
+
+        /** Used to match property names within property paths. */
+        var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\n\\]|\\.)*?)\2)\]/g;
+
+        /** Used to match backslashes in property paths. */
+        var reEscapeChar = /\\(\\)?/g;
+
+        /**
+         * Converts `value` to property path array if it's not one.
+         *
+         * @private
+         * @param {*} value The value to process.
+         * @returns {Array} Returns the property path array.
+         */
+        function toPath(value) {
+            if (isArray(value)) {
+                return value;
+            }
+            var result = [];
+            baseToString(value).replace(rePropName, function(match, number, quote, string) {
+                result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
+            });
+            return result;
+        }
+
+        module.exports = toPath;
+
+
+        /***/ },
+    /* 49 */
+    /***/ function(module, exports) {
+
+        /**
+         * Converts `value` to a string if it's not one. An empty string is returned
+         * for `null` or `undefined` values.
+         *
+         * @private
+         * @param {*} value The value to process.
+         * @returns {string} Returns the string.
+         */
+        function baseToString(value) {
+            return value == null ? '' : (value + '');
+        }
+
+        module.exports = baseToString;
+
+
+        /***/ },
+    /* 50 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseProperty = __ReactCssModules_require__(12),
+            basePropertyDeep = __ReactCssModules_require__(51),
+            isKey = __ReactCssModules_require__(46);
+
+        /**
+         * Creates a function that returns the property value at `path` on a
+         * given object.
+         *
+         * @static
+         * @memberOf _
+         * @category Utility
+         * @param {Array|string} path The path of the property to get.
+         * @returns {Function} Returns the new function.
+         * @example
+         *
+         * var objects = [
+         *   { 'a': { 'b': { 'c': 2 } } },
+         *   { 'a': { 'b': { 'c': 1 } } }
+         * ];
+         *
+         * _.map(objects, _.property('a.b.c'));
+         * // => [2, 1]
+         *
+         * _.pluck(_.sortBy(objects, _.property(['a', 'b', 'c'])), 'a.b.c');
+         * // => [1, 2]
+         */
+        function property(path) {
+            return isKey(path) ? baseProperty(path) : basePropertyDeep(path);
+        }
+
+        module.exports = property;
+
+
+        /***/ },
+    /* 51 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseGet = __ReactCssModules_require__(44),
+            toPath = __ReactCssModules_require__(48);
+
+        /**
+         * A specialized version of `baseProperty` which supports deep paths.
+         *
+         * @private
+         * @param {Array|string} path The path of the property to get.
+         * @returns {Function} Returns the new function.
+         */
+        function basePropertyDeep(path) {
+            var pathKey = (path + '');
+            path = toPath(path);
+            return function(object) {
+                return baseGet(object, path, pathKey);
+            };
+        }
+
+        module.exports = basePropertyDeep;
+
+
+        /***/ },
+    /* 52 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseEach = __ReactCssModules_require__(53),
+            isArrayLike = __ReactCssModules_require__(10);
+
+        /**
+         * The base implementation of `_.map` without support for callback shorthands
+         * and `this` binding.
+         *
+         * @private
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @returns {Array} Returns the new mapped array.
+         */
+        function baseMap(collection, iteratee) {
+            var index = -1,
+                result = isArrayLike(collection) ? Array(collection.length) : [];
+
+            baseEach(collection, function(value, key, collection) {
+                result[++index] = iteratee(value, key, collection);
+            });
+            return result;
+        }
+
+        module.exports = baseMap;
+
+
+        /***/ },
+    /* 53 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseForOwn = __ReactCssModules_require__(54),
+            createBaseEach = __ReactCssModules_require__(57);
+
+        /**
+         * The base implementation of `_.forEach` without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @returns {Array|Object|string} Returns `collection`.
+         */
+        var baseEach = createBaseEach(baseForOwn);
+
+        module.exports = baseEach;
+
+
+        /***/ },
+    /* 54 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseFor = __ReactCssModules_require__(55),
+            keys = __ReactCssModules_require__(6);
+
+        /**
+         * The base implementation of `_.forOwn` without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Object} object The object to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @returns {Object} Returns `object`.
+         */
+        function baseForOwn(object, iteratee) {
+            return baseFor(object, iteratee, keys);
+        }
+
+        module.exports = baseForOwn;
+
+
+        /***/ },
+    /* 55 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var createBaseFor = __ReactCssModules_require__(56);
+
+        /**
+         * The base implementation of `baseForIn` and `baseForOwn` which iterates
+         * over `object` properties returned by `keysFunc` invoking `iteratee` for
+         * each property. Iteratee functions may exit iteration early by explicitly
+         * returning `false`.
+         *
+         * @private
+         * @param {Object} object The object to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @param {Function} keysFunc The function to get the keys of `object`.
+         * @returns {Object} Returns `object`.
+         */
+        var baseFor = createBaseFor();
+
+        module.exports = baseFor;
+
+
+        /***/ },
+    /* 56 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var toObject = __ReactCssModules_require__(39);
+
+        /**
+         * Creates a base function for `_.forIn` or `_.forInRight`.
+         *
+         * @private
+         * @param {boolean} [fromRight] Specify iterating from right to left.
+         * @returns {Function} Returns the new base function.
+         */
+        function createBaseFor(fromRight) {
+            return function(object, iteratee, keysFunc) {
+                var iterable = toObject(object),
+                    props = keysFunc(object),
+                    length = props.length,
+                    index = fromRight ? length : -1;
+
+                while ((fromRight ? index-- : ++index < length)) {
+                    var key = props[index];
+                    if (iteratee(iterable[key], key, iterable) === false) {
+                        break;
+                    }
+                }
+                return object;
+            };
+        }
+
+        module.exports = createBaseFor;
+
+
+        /***/ },
+    /* 57 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var getLength = __ReactCssModules_require__(11),
+            isLength = __ReactCssModules_require__(13),
+            toObject = __ReactCssModules_require__(39);
+
+        /**
+         * Creates a `baseEach` or `baseEachRight` function.
+         *
+         * @private
+         * @param {Function} eachFunc The function to iterate over a collection.
+         * @param {boolean} [fromRight] Specify iterating from right to left.
+         * @returns {Function} Returns the new base function.
+         */
+        function createBaseEach(eachFunc, fromRight) {
+            return function(collection, iteratee) {
+                var length = collection ? getLength(collection) : 0;
+                if (!isLength(length)) {
+                    return eachFunc(collection, iteratee);
+                }
+                var index = fromRight ? length : -1,
+                    iterable = toObject(collection);
+
+                while ((fromRight ? index-- : ++index < length)) {
+                    if (iteratee(iterable[index], index, iterable) === false) {
+                        break;
+                    }
+                }
+                return collection;
+            };
+        }
+
+        module.exports = createBaseEach;
+
+
+        /***/ },
+    /* 58 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var arrayFilter = __ReactCssModules_require__(59),
+            baseCallback = __ReactCssModules_require__(29),
+            baseFilter = __ReactCssModules_require__(60),
+            isArray = __ReactCssModules_require__(16);
+
+        /**
+         * Iterates over elements of `collection`, returning an array of all elements
+         * `predicate` returns truthy for. The predicate is bound to `thisArg` and
+         * invoked with three arguments: (value, index|key, collection).
+         *
+         * If a property name is provided for `predicate` the created `_.property`
+         * style callback returns the property value of the given element.
+         *
+         * If a value is also provided for `thisArg` the created `_.matchesProperty`
+         * style callback returns `true` for elements that have a matching property
+         * value, else `false`.
+         *
+         * If an object is provided for `predicate` the created `_.matches` style
+         * callback returns `true` for elements that have the properties of the given
+         * object, else `false`.
+         *
+         * @static
+         * @memberOf _
+         * @alias select
+         * @category Collection
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function|Object|string} [predicate=_.identity] The function invoked
+         *  per iteration.
+         * @param {*} [thisArg] The `this` binding of `predicate`.
+         * @returns {Array} Returns the new filtered array.
+         * @example
+         *
+         * _.filter([4, 5, 6], function(n) {
+	 *   return n % 2 == 0;
+	 * });
+         * // => [4, 6]
+         *
+         * var users = [
+         *   { 'user': 'barney', 'age': 36, 'active': true },
+         *   { 'user': 'fred',   'age': 40, 'active': false }
+         * ];
+         *
+         * // using the `_.matches` callback shorthand
+         * _.pluck(_.filter(users, { 'age': 36, 'active': true }), 'user');
+         * // => ['barney']
+         *
+         * // using the `_.matchesProperty` callback shorthand
+         * _.pluck(_.filter(users, 'active', false), 'user');
+         * // => ['fred']
+         *
+         * // using the `_.property` callback shorthand
+         * _.pluck(_.filter(users, 'active'), 'user');
+         * // => ['barney']
+         */
+        function filter(collection, predicate, thisArg) {
+            var func = isArray(collection) ? arrayFilter : baseFilter;
+            predicate = baseCallback(predicate, thisArg, 3);
+            return func(collection, predicate);
+        }
+
+        module.exports = filter;
+
+
+        /***/ },
+    /* 59 */
+    /***/ function(module, exports) {
+
+        /**
+         * A specialized version of `_.filter` for arrays without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array} array The array to iterate over.
+         * @param {Function} predicate The function invoked per iteration.
+         * @returns {Array} Returns the new filtered array.
+         */
+        function arrayFilter(array, predicate) {
+            var index = -1,
+                length = array.length,
+                resIndex = -1,
+                result = [];
+
+            while (++index < length) {
+                var value = array[index];
+                if (predicate(value, index, array)) {
+                    result[++resIndex] = value;
+                }
+            }
+            return result;
+        }
+
+        module.exports = arrayFilter;
+
+
+        /***/ },
+    /* 60 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var baseEach = __ReactCssModules_require__(53);
+
+        /**
+         * The base implementation of `_.filter` without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function} predicate The function invoked per iteration.
+         * @returns {Array} Returns the new filtered array.
+         */
+        function baseFilter(collection, predicate) {
+            var result = [];
+            baseEach(collection, function(value, index, collection) {
+                if (predicate(value, index, collection)) {
+                    result.push(value);
+                }
+            });
+            return result;
+        }
+
+        module.exports = baseFilter;
+
+
+        /***/ },
+    /* 61 */
+    /***/ function(module, exports) {
+
+        module.exports = React;
+
+        /***/ },
+    /* 62 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _isBoolean = __ReactCssModules_require__(63);
+
+        var _isBoolean2 = _interopRequireDefault(_isBoolean);
+
+        var _isUndefined = __ReactCssModules_require__(64);
+
+        var _isUndefined2 = _interopRequireDefault(_isUndefined);
+
+        var _forEach = __ReactCssModules_require__(65);
+
+        var _forEach2 = _interopRequireDefault(_forEach);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        /**
+         * @typedef CSSModules~Options
+         * @see {@link https://github.com/gajus/react-css-modules#options}
+         * @property {boolean} allowMultiple
+         * @property {boolean} errorWhenNotFound
+         */
+
+        /**
+         * @param {CSSModules~Options} userConfiguration
+         * @return {CSSModules~Options}
+         */
+
+        exports.default = function () {
+            var userConfiguration = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+            var configuration = undefined;
+
+            configuration = {
+                allowMultiple: false,
+                errorWhenNotFound: true
+            };
+
+            (0, _forEach2.default)(userConfiguration, function (value, name) {
+                if ((0, _isUndefined2.default)(configuration[name])) {
+                    throw new Error('Unknown configuration property "' + name + '".');
+                }
+
+                if (!(0, _isBoolean2.default)(value)) {
+                    throw new Error('"' + name + '" property value must be a boolean.');
+                }
+
+                configuration[name] = value;
+            });
+
+            return configuration;
+        };
+        //# sourceMappingURL=makeConfiguration.js.map
+
+
+        /***/ },
+    /* 63 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var isObjectLike = __ReactCssModules_require__(9);
+
+        /** `Object#toString` result references. */
+        var boolTag = '[object Boolean]';
+
+        /** Used for native method references. */
+        var objectProto = Object.prototype;
+
+        /**
+         * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+         * of values.
+         */
+        var objToString = objectProto.toString;
+
+        /**
+         * Checks if `value` is classified as a boolean primitive or object.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+         * @example
+         *
+         * _.isBoolean(false);
+         * // => true
+         *
+         * _.isBoolean(null);
+         * // => false
+         */
+        function isBoolean(value) {
+            return value === true || value === false || (isObjectLike(value) && objToString.call(value) == boolTag);
+        }
+
+        module.exports = isBoolean;
+
+
+        /***/ },
+    /* 64 */
+    /***/ function(module, exports) {
+
+        /**
+         * Checks if `value` is `undefined`.
+         *
+         * @static
+         * @memberOf _
+         * @category Lang
+         * @param {*} value The value to check.
+         * @returns {boolean} Returns `true` if `value` is `undefined`, else `false`.
+         * @example
+         *
+         * _.isUndefined(void 0);
+         * // => true
+         *
+         * _.isUndefined(null);
+         * // => false
+         */
+        function isUndefined(value) {
+            return value === undefined;
+        }
+
+        module.exports = isUndefined;
+
+
+        /***/ },
+    /* 65 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var arrayEach = __ReactCssModules_require__(66),
+            baseEach = __ReactCssModules_require__(53),
+            createForEach = __ReactCssModules_require__(67);
+
+        /**
+         * Iterates over elements of `collection` invoking `iteratee` for each element.
+         * The `iteratee` is bound to `thisArg` and invoked with three arguments:
+         * (value, index|key, collection). Iteratee functions may exit iteration early
+         * by explicitly returning `false`.
+         *
+         * **Note:** As with other "Collections" methods, objects with a "length" property
+         * are iterated like arrays. To avoid this behavior `_.forIn` or `_.forOwn`
+         * may be used for object iteration.
+         *
+         * @static
+         * @memberOf _
+         * @alias each
+         * @category Collection
+         * @param {Array|Object|string} collection The collection to iterate over.
+         * @param {Function} [iteratee=_.identity] The function invoked per iteration.
+         * @param {*} [thisArg] The `this` binding of `iteratee`.
+         * @returns {Array|Object|string} Returns `collection`.
+         * @example
+         *
+         * _([1, 2]).forEach(function(n) {
+	 *   console.log(n);
+	 * }).value();
+         * // => logs each value from left to right and returns the array
+         *
+         * _.forEach({ 'a': 1, 'b': 2 }, function(n, key) {
+	 *   console.log(n, key);
+	 * });
+         * // => logs each value-key pair and returns the object (iteration order is not guaranteed)
+         */
+        var forEach = createForEach(arrayEach, baseEach);
+
+        module.exports = forEach;
+
+
+        /***/ },
+    /* 66 */
+    /***/ function(module, exports) {
+
+        /**
+         * A specialized version of `_.forEach` for arrays without support for callback
+         * shorthands and `this` binding.
+         *
+         * @private
+         * @param {Array} array The array to iterate over.
+         * @param {Function} iteratee The function invoked per iteration.
+         * @returns {Array} Returns `array`.
+         */
+        function arrayEach(array, iteratee) {
+            var index = -1,
+                length = array.length;
+
+            while (++index < length) {
+                if (iteratee(array[index], index, array) === false) {
+                    break;
+                }
+            }
+            return array;
+        }
+
+        module.exports = arrayEach;
+
+
+        /***/ },
+    /* 67 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        var bindCallback = __ReactCssModules_require__(22),
+            isArray = __ReactCssModules_require__(16);
+
+        /**
+         * Creates a function for `_.forEach` or `_.forEachRight`.
+         *
+         * @private
+         * @param {Function} arrayFunc The function to iterate over an array.
+         * @param {Function} eachFunc The function to iterate over a collection.
+         * @returns {Function} Returns the new each function.
+         */
+        function createForEach(arrayFunc, eachFunc) {
+            return function(collection, iteratee, thisArg) {
+                return (typeof iteratee == 'function' && thisArg === undefined && isArray(collection))
+                    ? arrayFunc(collection, iteratee)
+                    : eachFunc(collection, bindCallback(iteratee, thisArg, 3));
+            };
+        }
+
+        module.exports = createForEach;
+
+
+        /***/ },
+    /* 68 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _isObject = __ReactCssModules_require__(2);
+
+        var _isObject2 = _interopRequireDefault(_isObject);
+
+        var _isFunction = __ReactCssModules_require__(1);
+
+        var _isFunction2 = _interopRequireDefault(_isFunction);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        var ITERATOR_SYMBOL = undefined,
+            OLD_ITERATOR_SYMBOL = undefined;
+
+        ITERATOR_SYMBOL = (0, _isFunction2.default)(Symbol) && Symbol.iterator;
+        OLD_ITERATOR_SYMBOL = '@@iterator';
+
+        /**
+         * @see https://github.com/lodash/lodash/issues/1668
+         * @see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols
+         * @param {Object} target
+         * @returns {boolean}
+         */
+
+        exports.default = function (target) {
+            var iterator = undefined;
+
+            if (!(0, _isObject2.default)(target)) {
+                return false;
+            }
+
+            if (ITERATOR_SYMBOL) {
+                iterator = target[ITERATOR_SYMBOL];
+            } else {
+                iterator = target[OLD_ITERATOR_SYMBOL];
+            }
+
+            return (0, _isFunction2.default)(iterator);
+        };
+        //# sourceMappingURL=isIterable.js.map
+
+
+        /***/ },
+    /* 69 */
+    /***/ function(module, exports, __ReactCssModules_require__) {
+
+        'use strict';
+
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+
+        var _assign = __ReactCssModules_require__(4);
+
+        var _assign2 = _interopRequireDefault(_assign);
+
+        var _isObject = __ReactCssModules_require__(2);
+
+        var _isObject2 = _interopRequireDefault(_isObject);
+
+        var _linkClass = __ReactCssModules_require__(26);
+
+        var _linkClass2 = _interopRequireDefault(_linkClass);
+
+        var _react = __ReactCssModules_require__(61);
+
+        var _react2 = _interopRequireDefault(_react);
+
+        function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+        /* eslint-disable react/prop-types */
+
+        var wrapStatelessFunction = undefined;
+
+        /**
+         * @see https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
+         * @param {Function} Component
+         * @param {Object} defaultStyles
+         * @param {Object} options
+         * @returns {Function}
+         */
+        wrapStatelessFunction = function (Component, defaultStyles, options) {
+            var WrappedComponent = undefined;
+
+            WrappedComponent = function () {
+                for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+                    args[_key - 1] = arguments[_key];
+                }
+
+                var props = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+                var renderResult = undefined,
+                    styles = undefined,
+                    useProps = undefined;
+
+                if (props.styles) {
+                    useProps = props;
+                    styles = props.styles;
+                } else if ((0, _isObject2.default)(defaultStyles)) {
+                    useProps = (0, _assign2.default)({}, props, {
+                        styles: defaultStyles
+                    });
+
+                    styles = defaultStyles;
+                } else {
+                    useProps = props;
+                    styles = {};
+                }
+
+                renderResult = Component.apply(undefined, [useProps].concat(args));
+
+                if (renderResult) {
+                    return (0, _linkClass2.default)(renderResult, styles, options);
+                }
+
+                return _react2.default.createElement('noscript');
+            };
+
+            (0, _assign2.default)(WrappedComponent, Component);
+
+            return WrappedComponent;
+        };
+
+        exports.default = wrapStatelessFunction;
+        //# sourceMappingURL=wrapStatelessFunction.js.map
+
+
+        /***/ }
+    /******/ ]);


### PR DESCRIPTION
Allows anybody to use the library w/o adding the dependency to their application JS file. 
Should probably do the build automatically though. But in the meantime... 
The build was done using webpack and then replacing the webpackloader function name with ReactCssModules_webpack .

Why (Example) ?

GET libraries.min.js (contains ReactCssModules - minified - cached after first request or until redeploy)

GET application.min.js (contains application only code - minified - lighter - can have its cache destroyed often)