### PR TITLE
Expose wrapped component due to missing __proto__ support in IE <= 10

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -13,7 +13,7 @@ let extendReactClass;
  * @returns {ReactClass}
  */
 extendReactClass = (Component, defaultStyles, options) => {
-    return class extends Component {
+    class CssModule extends Component {
         render () {
             let renderResult,
                 styles;
@@ -38,7 +38,11 @@ extendReactClass = (Component, defaultStyles, options) => {
 
             return React.createElement('noscript');
         }
-    };
+    }
+
+    CssModule.WrappedComponent = Component;
+
+    return CssModule;
 };
 
 export default extendReactClass;

--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -45,6 +45,7 @@ wrapStatelessFunction = (Component, defaultStyles, options) => {
     };
 
     _.assign(WrappedComponent, Component);
+    WrappedComponent.WrappedComponent = Component;
 
     return WrappedComponent;
 };

--- a/tests/extendReactClass.js
+++ b/tests/extendReactClass.js
@@ -102,4 +102,16 @@ describe('extendReactClass', () => {
             expect(component.type).to.equal('noscript');
         });
     });
+    context('exposes properties since `__proto__` is not supported in IE <= 10', () => {
+        it('the wrapped component is exposed through the property `WrappedContent`', () => {
+            let Component = class extends React.Component {
+                render () {
+                    return null;
+                }
+            };
+
+            const ExtendedComponent = extendReactClass(Component);
+            expect(ExtendedComponent.WrappedComponent).to.equal(Component);
+        });
+    });
 });

--- a/tests/wrapStatelessFunction.js
+++ b/tests/wrapStatelessFunction.js
@@ -93,4 +93,13 @@ describe('wrapStatelessFunction', () => {
             expect(component.type).to.equal('noscript');
         });
     });
+
+    context('exposes properties since `__proto__` is not supported in IE <= 10', () => {
+        it('the wrapped component is exposed through the property `WrappedContent`', () => {
+            let fn = () => {};
+
+            const ExtendedComponent = wrapStatelessFunction(fn);
+            expect(ExtendedComponent.WrappedComponent).to.equal(fn);
+        });
+    });
 });


### PR DESCRIPTION
This PR exposes the wrapped component through a property on the higher order component. This allows workarounds with for lack of `__proto__` support in IE <= 10.

## Background
We are using `react-router` and `redux` and `react-redux` to handle our state and application flow. When we do page transition we look for static properties on our components (`fetchData` and `fetchDataDeferred`) that in turn dispatches actions related to data fetching for the new components. When we wrap our components using `react-css-modules` we can no longer get hold of the statics methods since they are wrapped in a higher order component. In the `react-redux`-bindings they have worked around this issue by exposing the wrapped component on the created higher order component. This PR does the same for `react-css-modules`.

## Related code in our project
```js
const getDataDependency = (component, methodName) => {
    return component.WrappedComponent ?
        getDataDependency(component.WrappedComponent, methodName) :
        component[methodName];
};

export default function getDataDependencies(
        components, getState, dispatch, location, params, deferred) 
{
    const methodName = deferred ? 'fetchDataDeferred' : 'fetchData';

    return components
        // Filter out `null`-components from `react-router`
        .filter(component => component) 
        // pull out fetch data methods
        .map(component => getDataDependency(component, methodName))
        // Ensure that the property is a function
        .filter(fetchData => typeof fetchData === 'function')
        // call fetch data method
        .map(fetchData =>
            fetchData({getState, dispatch, location, params}));
}
```