### PR TITLE
Simplify src/generateAppendClassName

### DIFF
--- a/src/generateAppendClassName.js
+++ b/src/generateAppendClassName.js
@@ -1,45 +1,11 @@
-import Map from 'es6-map';
-
-let stylesIndex;
-
-stylesIndex = new Map();
-
 export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): string => {
-    let appendClassName,
-        styleName,
-        stylesIndexMap;
-
-    stylesIndexMap = stylesIndex.get(styles);
-
-    if (stylesIndexMap) {
-        let styleNameIndex;
-
-        styleNameIndex = stylesIndexMap.get(styleNames);
-
-        if (styleNameIndex) {
-            return styleNameIndex;
-        }
-    } else {
-        stylesIndexMap = stylesIndex.set(styles, new Map());
-    }
-
-    appendClassName = '';
-
-    for (styleName in styleNames) {
-        let className;
-
-        className = styles[styleNames[styleName]];
-
-        if (className) {
-            appendClassName += ' ' + className;
-        } else if (errorWhenNotFound === true) {
-            throw new Error('"' + styleNames[styleName] + '" CSS module is undefined.');
-        }
-    }
-
-    appendClassName = appendClassName.trim();
-
-    stylesIndexMap.set(styleNames, appendClassName);
-
-    return appendClassName;
+    return styleNames.map(function (styleName) {
+      if (styles[styleName]) {
+        return styles[styleName];
+      } else if (errorWhenNotFound === true) {
+        throw new Error('"' + styleName + '" CSS module is undefined.');
+      } else {
+        return undefined;
+      }
+    }).join(' ').trim();
 };


### PR DESCRIPTION
- Removes requirements for an es6-map polyfill.
- Uses straight `Array#map`.
- Fixes a bug trying to check a style defined from `Array.prototype.func`