### PR TITLE
Remove styles from props after render

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -15,6 +15,7 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
     const WrappedComponent = class extends Component {
         render () {
             let styles;
+            let propsChanged = false;
 
             if (this.props.styles) {
                 styles = this.props.styles;
@@ -23,12 +24,17 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
                     styles: defaultStyles
                 });
 
+                propsChanged = true;
                 styles = defaultStyles;
             } else {
                 styles = {};
             }
 
             const renderResult = super.render();
+            
+            if(propsChanged) {
+                delete this.props.styles;
+            }
 
             if (renderResult) {
                 return linkClass(renderResult, styles, options);


### PR DESCRIPTION
Removing `styles` from `this.props` after render, in order not to hurt pure rendering logic.

If `this.props.styles` will remain, then shallow comparing props to newly received props will always return false.
(since even if nothing changed, the current props will have `styles: { ... }` and the new props will have `styles: undefined`)

resolves #102