### PR TITLE
have an option to use `stylesOverride` prop instead of `styles`

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -15,9 +15,10 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
     const WrappedComponent = class extends Component {
         render () {
             let styles;
+            let stylesOverrideAttribute = options.stylesPropOverride ? 'styles' : 'stylesOverride';
 
-            if (this.props.styles) {
-                styles = this.props.styles;
+            if (this.props[stylesOverrideAttribute]) {
+                styles = this.props[stylesOverrideAttribute];
             } else if (_.isObject(defaultStyles)) {
                 this.props = _.assign({}, this.props, {
                     styles: defaultStyles

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -25,7 +25,8 @@ export default (userConfiguration = {}) => {
 
     configuration = {
         allowMultiple: false,
-        errorWhenNotFound: true
+        errorWhenNotFound: true,
+        stylesPropOverride: true
     };
 
     _.forEach(userConfiguration, (value, name) => {


### PR DESCRIPTION
Allow passing `stylesPropOverride: false` in options, so that the `styles` prop will not override the styles.
(and instead will look for a more specific `stylesOverride` prop).

fixes #105