### PR TITLE
Allow default options to be overridden globally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,11 @@ import wrapStatelessFunction from './wrapStatelessFunction';
  */
 type OptionsType = {};
 
+export const globalOptions = {
+  allowMultiple: false,
+  errorWhenNotFound: true
+};
+
 /**
  * Determines if the given object has the signature of a class that inherits React.Component.
  */

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import Map from 'es6-map';
+import { globalOptions } from './index';
 
 const userConfigurationIndex = new Map();
 
@@ -23,10 +24,7 @@ export default (userConfiguration = {}) => {
         return configuration;
     }
 
-    configuration = {
-        allowMultiple: false,
-        errorWhenNotFound: true
-    };
+    configuration = { ...globalOptions };
 
     _.forEach(userConfiguration, (value, name) => {
         if (_.isUndefined(configuration[name])) {

--- a/tests/makeConfiguration.js
+++ b/tests/makeConfiguration.js
@@ -5,6 +5,7 @@ import {
 } from 'chai';
 
 import makeConfiguration from './../src/makeConfiguration';
+import { globalOptions } from './../src/index';
 
 describe('makeConfiguration', () => {
     describe('when using default configuration', () => {
@@ -31,6 +32,20 @@ describe('makeConfiguration', () => {
                     unknownProperty: true
                 });
             }).to.throw(Error, 'Unknown configuration property "unknownProperty".');
+        });
+    });
+    describe('when globalOptions are modified', () => {
+        let configuration;
+
+        beforeEach(() => {
+            globalOptions.allowMultiple = true;
+            configuration = makeConfiguration();
+        });
+        it('uses the new globalOptions', () => {
+            expect(configuration.allowMultiple).to.equal(true);
+        });
+        afterEach(() => {
+            globalOptions.allowMultiple = false;
         });
     });
     it('does not mutate user configuration', () => {


### PR DESCRIPTION
Expose a new variable call `globalOptions` that, when modified, changes the default options for all `react-css-modules` Components.

**Example code**:

```js
import CSSModules from 'react-css-modules';
// Only raise errors in non-production enviroments
CSSModules.globalOptions.errorWhenNotFound = process.env.NODE_ENV !== 'production';
// Allow multiple styleNames for every Component
CSSModules.globalOptions.allowMultiple = true;
```

**Why?**:

I few times now I've been cleaning up CSS files, deleted a class I thought wasn't being used anymore, deployed to production, and suddenly get a ton a errors from users that the react app stops working. This is my own fault for not having better tests around my components, but it would still be nice to be able to turn off and on these options globally based on the environment as shown.

What do you think?