### PR TITLE
Fixes memory leak in makeConfiguration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import extendReactClass from './extendReactClass';
 import wrapStatelessFunction from './wrapStatelessFunction';
+import makeConfiguration from './makeConfiguration';
 
 /**
  * @see https://github.com/gajus/react-css-modules#options
@@ -20,10 +21,12 @@ const isReactComponent = (maybeReactComponent: any): boolean => {
 const functionConstructor = (Component: Function, defaultStyles: Object, options: OptionsType): Function => {
     let decoratedClass;
 
+    const configuration = makeConfiguration(options);
+
     if (isReactComponent(Component)) {
-        decoratedClass = extendReactClass(Component, defaultStyles, options);
+        decoratedClass = extendReactClass(Component, defaultStyles, configuration);
     } else {
-        decoratedClass = wrapStatelessFunction(Component, defaultStyles, options);
+        decoratedClass = wrapStatelessFunction(Component, defaultStyles, configuration);
     }
 
     if (Component.displayName) {

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import React, {
     ReactElement
 } from 'react';
-import makeConfiguration from './makeConfiguration';
 import isIterable from './isIterable';
 import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
@@ -61,15 +60,13 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
 /**
  * @param {ReactElement} element
  * @param {Object} styles CSS modules class map.
- * @param {CSSModules~Options} userConfiguration
+ * @param {CSSModules~Options} configuration
  */
-export default (element: ReactElement, styles = {}, userConfiguration): ReactElement => {
+export default (element: ReactElement, styles = {}, configuration = {}): ReactElement => {
     // @see https://github.com/gajus/react-css-modules/pull/30
     if (!_.isObject(element)) {
         return element;
     }
-
-    const configuration = makeConfiguration(userConfiguration);
 
     return linkElement(element, styles, configuration);
 };

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -1,7 +1,4 @@
 import _ from 'lodash';
-import Map from 'es6-map';
-
-const userConfigurationIndex = new Map();
 
 /**
  * @typedef CSSModules~Options
@@ -15,15 +12,7 @@ const userConfigurationIndex = new Map();
  * @returns {CSSModules~Options}
  */
 export default (userConfiguration = {}) => {
-    let configuration;
-
-    configuration = userConfigurationIndex.get(userConfiguration);
-
-    if (configuration) {
-        return configuration;
-    }
-
-    configuration = {
+    const configuration = {
         allowMultiple: false,
         errorWhenNotFound: true
     };
@@ -39,8 +28,6 @@ export default (userConfiguration = {}) => {
 
         configuration[name] = value;
     });
-
-    userConfigurationIndex.set(userConfiguration, configuration);
 
     return configuration;
 };


### PR DESCRIPTION
This PR solves a memory leak when `userConfiguration` is undefined. 

Previously we would create a new entry in the map each time we called `makeConfiguration` without an argument since the default value would each time be a new object resulting in a fresh reference.

This also means that there actually still is a memory leak if `CSSModules` is called multiple times with the same values in the `options` but not with the same object.

```javascript
CSSModules(Component, styles, { allowMultiple: true });

CSSModules(Component, styles, { allowMultiple: true });
```

Both of these calls to `CSSModules` will create a new entry in the map. To avoid this the user would need to create an object and use it instead.

```javascript
const options = { allowMultiple: true };

CSSModules(Component, styles, options);

CSSModules(Component, styles, options);
```

I assume that what we would like to have here is cacheing on the values in the `options` and not the object reference itself. One way to achieve this would be to serialize the object and use the string as a reference. However when starting to do things like that it might be good to question if the caching is worth it.