### PR TITLE
add merge style support

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -4,6 +4,7 @@ import linkClass from './linkClass';
 import React from 'react';
 import _ from 'lodash';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import mergeStyles from './mergeStyles';
 
 /**
  * @param {ReactClass} Component
@@ -39,6 +40,9 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
             }
 
             if (renderResult) {
+                if (options && options.mergeStyles && _.isObject(defaultStyles)) {
+                    styles = mergeStyles(defaultStyles, styles);
+                }
                 return linkClass(renderResult, styles, options);
             }
 

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -25,6 +25,7 @@ export default (userConfiguration = {}) => {
 
     configuration = {
         allowMultiple: false,
+        mergeStyles: false,
         errorWhenNotFound: true
     };
 

--- a/src/mergeStyles.js
+++ b/src/mergeStyles.js
@@ -1,0 +1,16 @@
+import _ from 'lodash';
+
+export default (defaultStyles: Object, styles: Object) => {
+    let mergedStyles = _.assign({}, defaultStyles);
+
+    for (const p in mergedStyles) {
+        if (!mergedStyles.hasOwnProperty(p)) {
+            continue;
+        }
+        if (styles[p]) {
+            mergedStyles[p] += ' ' + styles[p];
+        }
+    }
+
+    return mergedStyles;
+}

--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 import React from 'react';
 import linkClass from './linkClass';
+import mergeStyles from './mergeStyles';
 
 /**
  * @see https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
@@ -29,6 +30,9 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
         const renderResult = Component(useProps, ...args);
 
         if (renderResult) {
+            if (options && options.mergeStyles && _.isObject(defaultStyles)) {
+                styles = mergeStyles(defaultStyles, styles);
+            }
             return linkClass(renderResult, styles, options);
         }
 


### PR DESCRIPTION
Hi,

I'd like to add this support for custom style merge into default, instead of simply override. I've used this code in our production to simplify the custom style override like this:

In component, nothing special, except for the options:
```
@CSSModule(styles, {mergeStyles: true})
export default class Dialog extends Component {
...
}

```
In its css, we have something like below:
```
.cancel-btn {
  color: black;
  ...
}
```

In component usage, we simply forward the styles down:
```
@CSSModule(styles)
export default class extends Component {
  render() {
    ...
    <Dialog styleName="hint-dialog" styles={styles} />
    ...
  }
}
```

Then, in the css, we can write as below to override part of the styles in dialog component.
```
.hint-dialog .cancel-btn {
  color: red;
}
```
