### PR TITLE
Added typeof check to Symbol in isIterable to avoid throwing a ReferenceError in iOS 8.0, mobile Safari 600.1.4

### DIFF
--- a/src/isIterable.js
+++ b/src/isIterable.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const ITERATOR_SYMBOL = _.isFunction(Symbol) && Symbol.iterator;
+const ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && _.isFunction(Symbol) && Symbol.iterator;
 const OLD_ITERATOR_SYMBOL = '@@iterator';
 
 /**


### PR DESCRIPTION
In iOS 8.0 safari, react-css-modules crashes my website when checking for Symbol support. Safari throws a ReferenceError when running _.isFunction on Symbol. 

Added a typeof guard to fix this issue.