### PR TITLE
Make style property generic and change from `styleName` to `data-style`

### DIFF
--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -8,6 +8,8 @@ import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
 import objectUnfreeze from 'object-unfreeze';
 
+const styleProperty = 'data-style';
+
 const linkElement = (element: ReactElement, styles: Object, configuration: Object): ReactElement => {
     let appendClassName,
         elementIsFrozen,
@@ -23,7 +25,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
         elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
     }
 
-    const styleNames = parseStyleName(elementShallowCopy.props.styleName || '', configuration.allowMultiple);
+    const styleNames = parseStyleName(elementShallowCopy.props[styleProperty] || '', configuration.allowMultiple);
 
     if (React.isValidElement(elementShallowCopy.props.children)) {
         elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, configuration);
@@ -46,7 +48,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
             }
 
             elementShallowCopy.props.className = appendClassName;
-            elementShallowCopy.props.styleName = null;
+            elementShallowCopy.props[styleProperty] = null;
         }
     }
 

--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -15,7 +15,7 @@ export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<s
     }
 
     if (allowMultiple === false && styleNames.length > 1) {
-        throw new Error('ReactElement styleName property defines multiple module names ("' + styleNamePropertyValue + '").');
+        throw new Error('ReactElement style property defines multiple module names ("' + styleNamePropertyValue + '").');
     }
 
     return styleNames;

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -244,23 +244,23 @@ describe('linkClass', () => {
     });
 
     it('does not warn for unknown style property', () => {
-      const originalWrite = process.stderr.write;
-      let warning = undefined;
+        const originalWrite = process.stderr.write;
+        let warning;
 
-      process.stderr.write = (function(write) {
-          return function(string, encoding, fd) {
-              write.apply(process.stderr, arguments)
-              if (string.indexOf('Unknown prop') > 0) {
-                warning = string;
-              }
-          }
-      })(process.stderr.write);
+        process.stderr.write = (function (write) {
+            return function (string, ...args) {
+                write.apply(process.stderr, [string, ...args]);
+                if (string.indexOf('Unknown prop') > 0) {
+                    warning = string;
+                }
+            };
+        })(process.stderr.write);
 
-      TestUtils.renderIntoDocument(linkClass(<div  {...{[styleProperty]: 'foo'}}></div>, {foo: 'foo-1'}));
+        TestUtils.renderIntoDocument(linkClass(<div {...{[styleProperty]: 'foo'}}></div>, {foo: 'foo-1'}));
 
-      process.stderr.write = originalWrite;
+        process.stderr.write = originalWrite;
 
-      expect(warning).to.be.undefined;
+        expect(warning).to.be.an('undefined');
     });
 
     context('when ReactElement includes ReactComponent', () => {

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -9,8 +9,10 @@ import TestUtils from 'react-addons-test-utils';
 import jsdom from 'jsdom';
 import linkClass from './../src/linkClass';
 
+const styleProperty = 'data-style';
+
 describe('linkClass', () => {
-    context('ReactElement does not define styleName', () => {
+    context('ReactElement does not define style property', () => {
         it('does not affect element properties', () => {
             expect(linkClass(<div></div>)).to.deep.equal(<div></div>);
         });
@@ -66,13 +68,13 @@ describe('linkClass', () => {
         });
     });
 
-    context('styleName matches an existing CSS module', () => {
-        context('when a descendant element has styleName', () => {
+    context('style property matches an existing CSS module', () => {
+        context('when a descendant element has style property', () => {
             it('assigns a generated className', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
+                    <p {...{[styleProperty]: 'foo'}}></p>
                 </div>;
 
                 subject = linkClass(subject, {
@@ -82,13 +84,13 @@ describe('linkClass', () => {
                 expect(subject.props.children.props.className).to.equal('foo-1');
             });
         });
-        context('when multiple descendant elements have styleName', () => {
+        context('when multiple descendant elements have style property', () => {
             it('assigns a generated className', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
-                    <p styleName='bar'></p>
+                    <p {...{[styleProperty]: 'foo'}}></p>
+                    <p {...{[styleProperty]: 'bar'}}></p>
                 </div>;
 
                 subject = linkClass(subject, {
@@ -99,12 +101,12 @@ describe('linkClass', () => {
                 expect(subject.props.children[0].props.className).to.equal('foo-1');
                 expect(subject.props.children[1].props.className).to.equal('bar-1');
             });
-            it('styleName is reset to null', () => {
+            it('style property is reset to null', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
-                    <p styleName='bar'></p>
+                    <p {...{[styleProperty]: 'foo'}}></p>
+                    <p {...{[styleProperty]: 'bar'}}></p>
                 </div>;
 
                 subject = linkClass(subject, {
@@ -112,17 +114,17 @@ describe('linkClass', () => {
                     foo: 'foo-1'
                 });
 
-                expect(subject.props.children[0].props.styleName).to.equal(null);
-                expect(subject.props.children[1].props.styleName).to.equal(null);
+                expect(subject.props.children[0].props[styleProperty]).to.equal(null);
+                expect(subject.props.children[1].props[styleProperty]).to.equal(null);
             });
         });
-        context('when multiple descendants have styleName and are iterable', () => {
+        context('when multiple descendants have style property and are iterable', () => {
             it('assigns a generated className', () => {
                 let subject;
 
                 const iterable = {
-                    0: <p key='1' styleName='foo'></p>,
-                    1: <p key='2' styleName='bar'></p>,
+                    0: <p key='1' {...{[styleProperty]: 'foo'}}></p>,
+                    1: <p key='2' {...{[styleProperty]: 'bar'}}></p>,
                     length: 2,
                     /* eslint-disable no-use-extend-native/no-use-extend-native */
                     [Symbol.iterator]: Array.prototype[Symbol.iterator]
@@ -144,7 +146,7 @@ describe('linkClass', () => {
             it('uses the generated class name to set the className property', () => {
                 let subject;
 
-                subject = <div styleName='foo'></div>;
+                subject = <div {...{[styleProperty]: 'foo'}}></div>;
 
                 subject = linkClass(subject, {
                     foo: 'foo-1'
@@ -157,7 +159,7 @@ describe('linkClass', () => {
             it('appends the generated class name to the className property', () => {
                 let subject;
 
-                subject = <div className='foo' styleName='bar'></div>;
+                subject = <div className='foo' {...{[styleProperty]: 'bar'}}></div>;
 
                 subject = linkClass(subject, {
                     bar: 'bar-1'
@@ -168,12 +170,12 @@ describe('linkClass', () => {
         });
     });
 
-    context('styleName includes multiple whitespace characters', () => {
+    context('style property includes multiple whitespace characters', () => {
         it('resolves CSS modules', () => {
             let subject;
 
             subject = <div>
-                <p styleName=' foo   bar '></p>
+                <p {...{[styleProperty]: ' foo   bar '}}></p>
             </div>;
 
             subject = linkClass(subject, {
@@ -192,15 +194,15 @@ describe('linkClass', () => {
             context('when false', () => {
                 it('throws an error', () => {
                     expect(() => {
-                        linkClass(<div styleName='foo bar'></div>, {}, {allowMultiple: false});
-                    }).to.throw(Error, 'ReactElement styleName property defines multiple module names ("foo bar").');
+                        linkClass(<div {...{[styleProperty]: 'foo bar'}}></div>, {}, {allowMultiple: false});
+                    }).to.throw(Error, 'ReactElement style property defines multiple module names ("foo bar").');
                 });
             });
             context('when true', () => {
                 it('appends a generated class name for every referenced CSS module', () => {
                     let subject;
 
-                    subject = <div styleName='foo bar'></div>;
+                    subject = <div {...{[styleProperty]: 'foo bar'}}></div>;
 
                     subject = linkClass(subject, {
                         bar: 'bar-1',
@@ -216,12 +218,12 @@ describe('linkClass', () => {
     });
 
     describe('options.errorWhenNotFound', () => {
-        context('when styleName does not match an existing CSS module', () => {
+        context('when style property does not match an existing CSS module', () => {
             context('when false', () => {
                 it('ignores the missing CSS module', () => {
                     let subject;
 
-                    subject = <div styleName='foo'></div>;
+                    subject = <div {...{[styleProperty]: 'foo'}}></div>;
 
                     subject = linkClass(subject, {}, {errorWhenNotFound: false});
 
@@ -231,7 +233,7 @@ describe('linkClass', () => {
             context('when is true', () => {
                 it('throws an error', () => {
                     expect(() => {
-                        linkClass(<div styleName='foo'></div>, {}, {errorWhenNotFound: true});
+                        linkClass(<div {...{[styleProperty]: 'foo'}}></div>, {}, {errorWhenNotFound: true});
                     }).to.throw(Error, '"foo" CSS module is undefined.');
                 });
             });
@@ -248,11 +250,11 @@ describe('linkClass', () => {
 
             Foo = class extends React.Component {
                 render () {
-                    return <div styleName='foo'>Hello</div>;
+                    return <div {...{[styleProperty]: 'foo'}}>Hello</div>;
                 }
             };
 
-            nodeList = TestUtils.renderIntoDocument(linkClass(<div styleName='foo'><Foo /></div>, {foo: 'foo-1'}));
+            nodeList = TestUtils.renderIntoDocument(linkClass(<div {...{[styleProperty]: 'foo'}}><Foo /></div>, {foo: 'foo-1'}));
         });
         it('processes ReactElement nodes', () => {
             expect(nodeList.className).to.equal('foo-1');
@@ -262,25 +264,25 @@ describe('linkClass', () => {
         });
     });
 
-    it('unsets styleName property of the target element', () => {
+    it('unsets style property of the target element', () => {
         let subject;
 
-        subject = <div styleName='foo'></div>;
+        subject = <div {...{[styleProperty]: 'foo'}}></div>;
 
         subject = linkClass(subject, {
             foo: 'foo-1'
         });
 
         expect(subject.props.className).to.deep.equal('foo-1');
-        expect(subject.props.styleName).to.deep.equal(null);
+        expect(subject.props[styleProperty]).to.deep.equal(null);
     });
 
-    it('unsets styleName property of the target element (deep)', () => {
+    it('unsets style property of the target element (deep)', () => {
         let subject;
 
-        subject = <div styleName='foo'>
-            <div styleName='bar'></div>
-            <div styleName='bar'></div>
+        subject = <div {...{[styleProperty]: 'foo'}}>
+            <div {...{[styleProperty]: 'bar'}}></div>
+            <div {...{[styleProperty]: 'bar'}}></div>
         </div>;
 
         subject = linkClass(subject, {
@@ -289,6 +291,6 @@ describe('linkClass', () => {
         });
 
         expect(subject.props.children[0].props.className).to.deep.equal('bar-1');
-        expect(subject.props.children[0].props.styleName).to.deep.equal(null);
+        expect(subject.props.children[0].props[styleProperty]).to.deep.equal(null);
     });
 });

--- a/tests/reactCssModules.js
+++ b/tests/reactCssModules.js
@@ -10,6 +10,8 @@ import TestUtils from 'react-addons-test-utils';
 import jsdom from 'jsdom';
 import reactCssModules from './../src/index';
 
+const styleProperty = 'data-style';
+
 describe('reactCssModules', () => {
     context('a ReactComponent is decorated using react-css-modules', () => {
         it('inherits displayName', () => {
@@ -36,7 +38,7 @@ describe('reactCssModules', () => {
             });
         });
     });
-    context('a ReactComponent renders an element with the styleName prop', () => {
+    context('a ReactComponent renders an element with the style property', () => {
         context('the component is a class that extends React.Component', () => {
             it('that element should contain the equivalent className', () => {
                 let Foo;
@@ -45,7 +47,7 @@ describe('reactCssModules', () => {
 
                 Foo = class extends React.Component {
                     render () {
-                        return <div styleName='foo'>Hello</div>;
+                        return <div {...{[styleProperty]: 'foo'}}>Hello</div>;
                     }
                 };
 
@@ -67,7 +69,7 @@ describe('reactCssModules', () => {
                 const shallowRenderer = TestUtils.createRenderer();
 
                 Foo = () => {
-                    return <div styleName='foo'>Hello</div>;
+                    return <div {...{[styleProperty]: 'foo'}}>Hello</div>;
                 };
 
                 Foo = reactCssModules(Foo, {
@@ -136,7 +138,7 @@ describe('reactCssModules', () => {
         });
         context('parent component is using react-css-modules and interpolates props.children', () => {
             // @see https://github.com/gajus/react-css-modules/issues/76
-            it('unsets the styleName property', () => {
+            it('unsets the style property', () => {
                 let Bar,
                     Foo,
                     subject;
@@ -144,7 +146,7 @@ describe('reactCssModules', () => {
                 Foo = class extends React.Component {
                     render () {
                         return <Bar>
-                            <div styleName='test'>foo</div>
+                            <div {...{[styleProperty]: 'test'}}>foo</div>
                         </Bar>;
                     }
                 };


### PR DESCRIPTION
This is a demonstration of one way to correct the warnings now being thrown by react-css-modules in certain cases, due to https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b. See #147 for discussion.