### PR TITLE
Update generateAppendClassName.js

### DIFF
--- a/src/generateAppendClassName.js
+++ b/src/generateAppendClassName.js
@@ -15,7 +15,8 @@ export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): 
             return styleNameIndex;
         }
     } else {
-        stylesIndexMap = stylesIndex.set(styles, new Map());
+        stylesIndex.set(styles, new _simpleMap2.default());
+        stylesIndexMap = new Map(stylesIndex);
     }
 
     appendClassName = '';


### PR DESCRIPTION
This is to fix this code failing on most IE browsers.

Even though stylesIndex.set(styles, new Map()); is setting stylesIndex properly, it doesn't seem to be returning a new map because stylesIndexMap remains undefined.

if stylesIndexMap is undefined the code fails further down at the line

stylesIndexMap.set(styleNames, appendClassName);

My code change fixes this