### PR TITLE
Update .npmignore to no longer exclude src/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 tests
 coverage
 .*


### PR DESCRIPTION
If you try to use react-css-modules with the babel-modern preset, one of the transforms used in the distribution process is incompatible.

This is probably an edge case, but I want to include the source directly, let my babel loader know about it, and then use the babel-modern preset.   

Can you start distributing the source folder in npm packages please?  Thanks!