### PR TITLE
Fix typo in class name example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Rendering the component will produce a markup similar to:
 ```js
 <div class="table__table___32osj">
     <div class="table__row___2w27N">
-        <div class="table__cell___2w27N">A0</div>
+        <div class="table__cell___1oVw5">A0</div>
         <div class="table__cell___1oVw5">B0</div>
     </div>
 </div>


### PR DESCRIPTION
Cell element from the rendering output example has a class that looks like some mix of `styles.row` and `styles.cell`, but it should have exactly the same class from `styles.cell` as the other cell element.