### PR TITLE
Remove lodash dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
         "add-module-exports",
 	"transform-class-properties",
 	["transform-es2015-classes", { "loose": true }],
-	"transform-proto-to-assign"
+	"transform-proto-to-assign",
+	"transform-object-assign"
     ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,6 @@
     ],
     "plugins": [
         "add-module-exports",
-        "lodash",
 	"transform-class-properties",
 	["transform-es2015-classes", { "loose": true }],
 	"transform-proto-to-assign"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-object-assign": "^1.2.1",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-object-assign": "^1.2.1",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "hoist-non-react-statics": "^1.0.5",
-    "lodash": "^4.6.1",
     "object-unfreeze": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-lodash": "^3.2.5",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",

--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import _ from 'lodash';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import linkClass from './linkClass';
+import {isObject} from './utils';
 
 /**
  * @param {ReactClass} Component
@@ -14,15 +14,13 @@ import linkClass from './linkClass';
 export default (Component: Object, defaultStyles: Object, options: Object) => {
     const WrappedComponent = class extends Component {
         render () {
-            let propsChanged,
+            let propsChanged = false,
                 styles;
-
-            propsChanged = false;
 
             if (this.props.styles) {
                 styles = this.props.styles;
-            } else if (_.isObject(defaultStyles)) {
-                this.props = _.assign({}, this.props, {
+            } else if (isObject(defaultStyles)) {
+                this.props = Object.assign({}, this.props, {
                     styles: defaultStyles
                 });
 

--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -14,8 +14,10 @@ import {isObject} from './utils';
 export default (Component: Object, defaultStyles: Object, options: Object) => {
     const WrappedComponent = class extends Component {
         render () {
-            let propsChanged = false,
+            let propsChanged,
                 styles;
+
+            propsChanged = false;
 
             if (this.props.styles) {
                 styles = this.props.styles;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import extendReactClass from './extendReactClass';
 import wrapStatelessFunction from './wrapStatelessFunction';
 import makeConfiguration from './makeConfiguration';
+import {isFunction} from './utils';
 
 /**
  * @see https://github.com/gajus/react-css-modules#options
@@ -12,7 +13,7 @@ type TypeOptions = {};
  * Determines if the given object has the signature of a class that inherits React.Component.
  */
 const isReactComponent = (maybeReactComponent: any): boolean => {
-    return 'prototype' in maybeReactComponent && _.isFunction(maybeReactComponent.prototype.render);
+    return 'prototype' in maybeReactComponent && isFunction(maybeReactComponent.prototype.render);
 };
 
 /**
@@ -48,7 +49,7 @@ const decoratorConstructor = (defaultStyles: Object, options: TypeOptions): Func
 };
 
 export default (...args) => {
-    if (_.isFunction(args[0])) {
+    if (isFunction(args[0])) {
         return functionConstructor(args[0], args[1], args[2]);
     } else {
         return decoratorConstructor(args[0], args[1]);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import extendReactClass from './extendReactClass';
 import wrapStatelessFunction from './wrapStatelessFunction';
 import makeConfiguration from './makeConfiguration';

--- a/src/isIterable.js
+++ b/src/isIterable.js
@@ -1,6 +1,6 @@
-import _ from 'lodash';
+import {isFunction, isObject} from './utils';
 
-const ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && _.isFunction(Symbol) && Symbol.iterator;
+const ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && isFunction(Symbol) && Symbol.iterator;
 const OLD_ITERATOR_SYMBOL = '@@iterator';
 
 /**
@@ -10,7 +10,7 @@ const OLD_ITERATOR_SYMBOL = '@@iterator';
 export default (maybeIterable: any): boolean => {
     let iterator;
 
-    if (!_.isObject(maybeIterable)) {
+    if (!isObject(maybeIterable)) {
         return false;
     }
 
@@ -20,5 +20,5 @@ export default (maybeIterable: any): boolean => {
         iterator = maybeIterable[OLD_ITERATOR_SYMBOL];
     }
 
-    return _.isFunction(iterator);
+    return isFunction(iterator);
 };

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -5,7 +5,7 @@ import objectUnfreeze from 'object-unfreeze';
 import isIterable from './isIterable';
 import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
-import {isObject} from './utils';
+import {isObject, isArray} from './utils';
 
 const linkElement = (element: ReactElement, styles: Object, configuration: Object): ReactElement => {
     let appendClassName,
@@ -26,7 +26,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
 
     if (React.isValidElement(elementShallowCopy.props.children)) {
         elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, configuration);
-    } else if (Array.isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
+    } else if (isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
         elementShallowCopy.props.children = React.Children.map(elementShallowCopy.props.children, (node) => {
             if (React.isValidElement(node)) {
                 return linkElement(node, styles, configuration);

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, {
     ReactElement
 } from 'react';
@@ -6,6 +5,7 @@ import objectUnfreeze from 'object-unfreeze';
 import isIterable from './isIterable';
 import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
+import {isObject} from './utils';
 
 const linkElement = (element: ReactElement, styles: Object, configuration: Object): ReactElement => {
     let appendClassName,
@@ -26,7 +26,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
 
     if (React.isValidElement(elementShallowCopy.props.children)) {
         elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, configuration);
-    } else if (_.isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
+    } else if (Array.isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
         elementShallowCopy.props.children = React.Children.map(elementShallowCopy.props.children, (node) => {
             if (React.isValidElement(node)) {
                 return linkElement(node, styles, configuration);
@@ -65,7 +65,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
  */
 export default (element: ReactElement, styles = {}, configuration = {}): ReactElement => {
     // @see https://github.com/gajus/react-css-modules/pull/30
-    if (!_.isObject(element)) {
+    if (!isObject(element)) {
         return element;
     }
 

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -15,7 +15,7 @@ export default (userConfiguration = {}) => {
         errorWhenNotFound: true
     };
 
-    Object.keys(userConfiguration).forEach(name => {
+    for(const name in userConfiguration) {
         const value = userConfiguration[name];
 
         if (!(name in configuration)) {
@@ -27,7 +27,7 @@ export default (userConfiguration = {}) => {
         }
 
         configuration[name] = value;
-    });
+    }
 
     return configuration;
 };

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 /**
  * @typedef CSSModules~Options
  * @see {@link https://github.com/gajus/react-css-modules#options}
@@ -17,12 +15,14 @@ export default (userConfiguration = {}) => {
         errorWhenNotFound: true
     };
 
-    _.forEach(userConfiguration, (value, name) => {
-        if (_.isUndefined(configuration[name])) {
+    Object.keys(userConfiguration).forEach(name => {
+        const value = userConfiguration[name];
+
+        if (!(name in configuration)) {
             throw new Error('Unknown configuration property "' + name + '".');
         }
 
-        if (!_.isBoolean(value)) {
+        if (value !== true && value !== false) {
             throw new Error('"' + name + '" property value must be a boolean.');
         }
 

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -15,18 +15,20 @@ export default (userConfiguration = {}) => {
         errorWhenNotFound: true
     };
 
-    for(const name in userConfiguration) {
-        const value = userConfiguration[name];
+    for (const name in userConfiguration) {
+        if (userConfiguration.hasOwnProperty(name)) {
+            const value = userConfiguration[name];
 
-        if (!(name in configuration)) {
-            throw new Error('Unknown configuration property "' + name + '".');
+            if (!(name in configuration)) {
+                throw new Error('Unknown configuration property "' + name + '".');
+            }
+
+            if (value !== true && value !== false) {
+                throw new Error('"' + name + '" property value must be a boolean.');
+            }
+
+            configuration[name] = value;
         }
-
-        if (value !== true && value !== false) {
-            throw new Error('"' + name + '" property value must be a boolean.');
-        }
-
-        configuration[name] = value;
     }
 
     return configuration;

--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -1,5 +1,6 @@
-const styleNameIndex = {};
 import {trim, filterForTruthy} from './utils';
+
+const styleNameIndex = {};
 
 export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<string> => {
     let styleNames;

--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -1,4 +1,5 @@
 const styleNameIndex = {};
+import {trim, filterForTruthy} from './utils';
 
 export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<string> => {
     let styleNames;
@@ -6,7 +7,7 @@ export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<s
     if (styleNameIndex[styleNamePropertyValue]) {
         styleNames = styleNameIndex[styleNamePropertyValue];
     } else {
-        styleNames = styleNamePropertyValue.trim().split(' ').filter(e => !!e);
+        styleNames = filterForTruthy(trim(styleNamePropertyValue).split(' '));
 
         styleNameIndex[styleNamePropertyValue] = styleNames;
     }

--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 const styleNameIndex = {};
 
 export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<string> => {
@@ -8,8 +6,7 @@ export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<s
     if (styleNameIndex[styleNamePropertyValue]) {
         styleNames = styleNameIndex[styleNamePropertyValue];
     } else {
-        styleNames = _.trim(styleNamePropertyValue).split(' ');
-        styleNames = _.filter(styleNames);
+        styleNames = styleNamePropertyValue.trim().split(' ').filter(e => !!e);
 
         styleNameIndex[styleNamePropertyValue] = styleNames;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,3 +8,7 @@ export function isFunction(func) {
             || Object.prototype.toString.call(func) === '[object GeneratorFunction]'
         );
 }
+
+export function isArray(arr) {
+    return Array.isArray ? Array.isArray(arr) : Object.prototype.toString.call(arr) === '[object Array]';
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,3 +12,18 @@ export function isFunction(func) {
 export function isArray(arr) {
     return Array.isArray ? Array.isArray(arr) : Object.prototype.toString.call(arr) === '[object Array]';
 }
+
+export function trim(str) {
+    return String.prototype.trim ? str.trim() : str.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+}
+
+export function filterForTruthy(arr) {
+    const results = [];
+    for(const key in arr) {
+        if(arr[key]) {
+            results.push(arr[key]);
+        }
+    }
+
+    return results;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,10 @@
+export function isObject(obj) {
+    return obj === Object(obj);
+}
+
+export function isFunction(func) {
+    return (
+            Object.prototype.toString.call(func) === '[object Function]'
+            || Object.prototype.toString.call(func) === '[object GeneratorFunction]'
+        );
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,29 +1,30 @@
-export function isObject(obj) {
+export const isObject = function (obj) {
     return obj === Object(obj);
-}
+};
 
-export function isFunction(func) {
+export const isFunction = function (func) {
     return (
-            Object.prototype.toString.call(func) === '[object Function]'
-            || Object.prototype.toString.call(func) === '[object GeneratorFunction]'
-        );
-}
+        Object.prototype.toString.call(func) === '[object Function]' ||
+        Object.prototype.toString.call(func) === '[object GeneratorFunction]'
+    );
+};
 
-export function isArray(arr) {
+export const isArray = function (arr) {
     return Array.isArray ? Array.isArray(arr) : Object.prototype.toString.call(arr) === '[object Array]';
-}
+};
 
-export function trim(str) {
+export const trim = function (str) {
     return String.prototype.trim ? str.trim() : str.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
-}
+};
 
-export function filterForTruthy(arr) {
+export const filterForTruthy = function (arr) {
     const results = [];
-    for(const key in arr) {
-        if(arr[key]) {
+
+    for (const key in arr) {
+        if (arr[key]) {
             results.push(arr[key]);
         }
     }
 
     return results;
-}
+};

--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 
-import _ from 'lodash';
 import React from 'react';
 import linkClass from './linkClass';
+import {isObject} from './utils';
 
 /**
  * @see https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
@@ -15,8 +15,8 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
         if (props.styles) {
             useProps = props;
             styles = props.styles;
-        } else if (_.isObject(defaultStyles)) {
-            useProps = _.assign({}, props, {
+        } else if (isObject(defaultStyles)) {
+            useProps = Object.assign({}, props, {
                 styles: defaultStyles
             });
 
@@ -35,7 +35,7 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
         return React.createElement('noscript');
     };
 
-    _.assign(WrappedComponent, Component);
+    Object.assign(WrappedComponent, Component);
 
     return WrappedComponent;
 };

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -11,11 +11,11 @@ import linkClass from './../src/linkClass';
 describe('linkClass', () => {
     context('ReactElement does not define styleName', () => {
         it('does not affect element properties', () => {
-            expect(linkClass(<div></div>)).to.deep.equal(<div></div>);
+            expect(linkClass(<div />)).to.deep.equal(<div />);
         });
 
         it('does not affect element properties with a single element child', () => {
-            expect(linkClass(<div><p></p></div>)).to.deep.equal(<div><p></p></div>);
+            expect(linkClass(<div><p /></div>)).to.deep.equal(<div><p /></div>);
         });
 
         it('does not affect element properties with a single text child', () => {
@@ -23,7 +23,7 @@ describe('linkClass', () => {
         });
 
         it('does not affect the className', () => {
-            expect(linkClass(<div className='foo'></div>)).to.deep.equal(<div className='foo'></div>);
+            expect(linkClass(<div className='foo' />)).to.deep.equal(<div className='foo' />);
         });
 
         xit('does not affect element with a single children when that children is contained in an array', () => {
@@ -71,7 +71,7 @@ describe('linkClass', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
+                    <p styleName='foo' />
                 </div>;
 
                 subject = linkClass(subject, {
@@ -86,8 +86,8 @@ describe('linkClass', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
-                    <p styleName='bar'></p>
+                    <p styleName='foo' />
+                    <p styleName='bar' />
                 </div>;
 
                 subject = linkClass(subject, {
@@ -102,8 +102,8 @@ describe('linkClass', () => {
                 let subject;
 
                 subject = <div>
-                    <p styleName='foo'></p>
-                    <p styleName='bar'></p>
+                    <p styleName='foo' />
+                    <p styleName='bar' />
                 </div>;
 
                 subject = linkClass(subject, {
@@ -120,8 +120,8 @@ describe('linkClass', () => {
                 let subject;
 
                 const iterable = {
-                    0: <p key='1' styleName='foo'></p>,
-                    1: <p key='2' styleName='bar'></p>,
+                    0: <p key='1' styleName='foo' />,
+                    1: <p key='2' styleName='bar' />,
                     length: 2,
                     /* eslint-disable no-use-extend-native/no-use-extend-native */
                     [Symbol.iterator]: Array.prototype[Symbol.iterator]
@@ -143,7 +143,7 @@ describe('linkClass', () => {
             it('uses the generated class name to set the className property', () => {
                 let subject;
 
-                subject = <div styleName='foo'></div>;
+                subject = <div styleName='foo' />;
 
                 subject = linkClass(subject, {
                     foo: 'foo-1'
@@ -156,7 +156,7 @@ describe('linkClass', () => {
             it('appends the generated class name to the className property', () => {
                 let subject;
 
-                subject = <div className='foo' styleName='bar'></div>;
+                subject = <div className='foo' styleName='bar' />;
 
                 subject = linkClass(subject, {
                     bar: 'bar-1'
@@ -172,7 +172,7 @@ describe('linkClass', () => {
             let subject;
 
             subject = <div>
-                <p styleName=' foo   bar '></p>
+                <p styleName=' foo   bar ' />
             </div>;
 
             subject = linkClass(subject, {
@@ -191,7 +191,7 @@ describe('linkClass', () => {
             context('when false', () => {
                 it('throws an error', () => {
                     expect(() => {
-                        linkClass(<div styleName='foo bar'></div>, {}, {allowMultiple: false});
+                        linkClass(<div styleName='foo bar' />, {}, {allowMultiple: false});
                     }).to.throw(Error, 'ReactElement styleName property defines multiple module names ("foo bar").');
                 });
             });
@@ -199,7 +199,7 @@ describe('linkClass', () => {
                 it('appends a generated class name for every referenced CSS module', () => {
                     let subject;
 
-                    subject = <div styleName='foo bar'></div>;
+                    subject = <div styleName='foo bar' />;
 
                     subject = linkClass(subject, {
                         bar: 'bar-1',
@@ -220,7 +220,7 @@ describe('linkClass', () => {
                 it('ignores the missing CSS module', () => {
                     let subject;
 
-                    subject = <div styleName='foo'></div>;
+                    subject = <div styleName='foo' />;
 
                     subject = linkClass(subject, {}, {errorWhenNotFound: false});
 
@@ -230,7 +230,7 @@ describe('linkClass', () => {
             context('when is true', () => {
                 it('throws an error', () => {
                     expect(() => {
-                        linkClass(<div styleName='foo'></div>, {}, {errorWhenNotFound: true});
+                        linkClass(<div styleName='foo' />, {}, {errorWhenNotFound: true});
                     }).to.throw(Error, '"foo" CSS module is undefined.');
                 });
             });
@@ -264,7 +264,7 @@ describe('linkClass', () => {
     it('deletes styleName property from the target element', () => {
         let subject;
 
-        subject = <div styleName='foo'></div>;
+        subject = <div styleName='foo' />;
 
         subject = linkClass(subject, {
             foo: 'foo-1'
@@ -278,8 +278,8 @@ describe('linkClass', () => {
         let subject;
 
         subject = <div styleName='foo'>
-            <div styleName='bar'></div>
-            <div styleName='bar'></div>
+            <div styleName='bar' />
+            <div styleName='bar' />
         </div>;
 
         subject = linkClass(subject, {

--- a/tests/reactCssModules.js
+++ b/tests/reactCssModules.js
@@ -174,7 +174,7 @@ describe('reactCssModules', () => {
 
                 subject = TestUtils.renderIntoDocument(<Foo />);
 
-                subject = ReactDOM.findDOMNode(subject);
+                subject = ReactDOM.findDOMNode(subject); // eslint-disable-line react/no-find-dom-node
 
                 expect(subject.firstChild.className).to.equal('foo-0');
             });


### PR DESCRIPTION
Hey there,

I noticed you had done some work recently to reduce the bundle size incurred by using lodash, so I went ahead and pulled all of it out.

Here's what I did:

1. I created `utils.js` with IE8-compatible implementations of `isFunction()`, `isArray()` and `isObject()`.
2. I replaced calls to `_.isFunction()`,` _.isArray()` and `_.isObject()` with those implementations.
3. I replaced calls to `_.assign()` with `Object.assign()` and added `babel-plugin-transform-object-assign` to maintain IE8 compatibility with `_.assign()`.  
4. I replaced a call to `_.isUndefined(map[key])` with `(!(key in map))`.
5. I replaced a call to `_.forEach(obj)` with `for(const key in obj)`.
6. I replaced a call to `_.trim()` with a `trim()` implementation that uses `str.trim()` or a regex if it's not there for IE8 support.
7. I replaced a call to `_.filter()` with a `filterForTruthy()` function.

If you don't care about IE8 support, let me know because a lot of the code here is for IE8 support.

Thanks!

