### PR TITLE
SimpleMap polyfill breaks IE8 even if Map is already polyfiled

### DIFF
--- a/src/simple-map.js
+++ b/src/simple-map.js
@@ -1,11 +1,8 @@
 export class SimpleMap {
     constructor () {
+        this.size = 0;
         this.keys = [];
         this.values = [];
-    }
-
-    get size () {
-        return this.keys.length;
     }
 
     get (key) {
@@ -17,6 +14,7 @@ export class SimpleMap {
     set (key, value) {
         this.keys.push(key);
         this.values.push(value);
+        this.size = this.keys.length;
 
         return value;
     }

--- a/src/simple-map.js
+++ b/src/simple-map.js
@@ -1,4 +1,4 @@
-export class SimpleMap {
+export const createSimpleMap = () => class SimpleMap {
     constructor () {
         this.size = 0;
         this.keys = [];
@@ -18,8 +18,8 @@ export class SimpleMap {
 
         return value;
     }
-}
+};
 
-const exportedMap = typeof Map === 'undefined' ? SimpleMap : Map;
+const exportedMap = typeof Map === 'undefined' ? createSimpleMap() : Map;
 
 export default exportedMap;

--- a/tests/simple-map.js
+++ b/tests/simple-map.js
@@ -1,7 +1,7 @@
 import {
     expect
 } from 'chai';
-import {SimpleMap} from './../src/simple-map';
+import {createSimpleMap} from './../src/simple-map';
 
 const getTests = (map) => {
     return () => {
@@ -28,6 +28,8 @@ const getTests = (map) => {
 };
 
 describe('SimpleMap', () => {
+    const SimpleMap = createSimpleMap();
+
     context('simple map with primitive or object as keys', getTests(new SimpleMap()));
     if (typeof Map !== 'undefined') {
         context('sanity - running tests against native Map', getTests(new Map()));


### PR DESCRIPTION
`simple-map.js` defines a `size` getter. But getters and setters are not supported by legacy JS engines and can not be polyfiled there.

`Map` could be polyfiled in IE8. But `simple-map.js` creates IE8-incompatible `SimpleMap` class even if `Map` is already defined.

I can see two possible solutions for this problem:

1. To wrap `SimpleMap` class creation in a factory function to let users include their own IE8-compatible `Map` polyfill.
2. To get rid of `size` getter by replacing it with regularly updated property.

I'll be happy to submit a pull request with any of those solutions.