### PR TITLE
Remove lodash as dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,15 @@
 {
-    "presets": [
-        "es2015",
-        "stage-0",
-        "react"
-    ],
-    "plugins": [
-        "add-module-exports",
-        "lodash",
-	"transform-class-properties",
-	["transform-es2015-classes", { "loose": true }],
-	"transform-proto-to-assign"
-    ]
+  "presets": [
+    "es2015",
+    "stage-0",
+    "react"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "lodash",
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    ["transform-es2015-classes", { "loose": true }],
+    "transform-proto-to-assign"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "hoist-non-react-statics": "^1.0.5",
-    "lodash": "^4.6.1",
     "object-unfreeze": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "^3.2.5",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
@@ -38,6 +38,7 @@
     "eslint-config-canonical": "^1.7.12",
     "husky": "^0.11.7",
     "jsdom": "^9.5.0",
+    "lodash": "^4.16.6",
     "mocha": "^3.0.2",
     "react": "^15.0.0-rc.1",
     "react-addons-shallow-compare": "^15.0.0-rc.1",
@@ -46,6 +47,7 @@
   },
   "scripts": {
     "lint": "eslint ./src ./tests",
+    "lint:fix": "eslint --fix ./src ./tests",
     "test": "mocha --compilers js:babel-register ./tests/**/*.js",
     "build": "babel ./src --out-dir ./dist",
     "precommit": "npm run lint && npm run test"

--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import _ from 'lodash';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import linkClass from './linkClass';
+import {isObject} from './util';
 
 /**
  * @param {ReactClass} Component
@@ -21,7 +21,7 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
 
       if (this.props.styles) {
         styles = this.props.styles;
-      } else if (_.isObject(defaultStyles)) {
+      } else if (isObject(defaultStyles)) {
         const props = Object.assign({}, this.props);
 
         Object.defineProperty(props, 'styles', {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import {isFunction} from './util';
 import extendReactClass from './extendReactClass';
 import wrapStatelessFunction from './wrapStatelessFunction';
 import makeConfiguration from './makeConfiguration';
@@ -12,7 +12,7 @@ type TypeOptions = {};
  * Determines if the given object has the signature of a class that inherits React.Component.
  */
 const isReactComponent = (maybeReactComponent: any): boolean => {
-  return 'prototype' in maybeReactComponent && _.isFunction(maybeReactComponent.prototype.render);
+  return 'prototype' in maybeReactComponent && isFunction(maybeReactComponent.prototype.render);
 };
 
 /**
@@ -48,7 +48,7 @@ const decoratorConstructor = (defaultStyles: Object, options: TypeOptions): Func
 };
 
 export default (...args) => {
-  if (_.isFunction(args[0])) {
+  if (isFunction(args[0])) {
     return functionConstructor(args[0], args[1], args[2]);
   } else {
     return decoratorConstructor(args[0], args[1]);

--- a/src/isIterable.js
+++ b/src/isIterable.js
@@ -1,6 +1,6 @@
-import _ from 'lodash';
+import {isObject, isFunction} from './util' ;
 
-const ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && _.isFunction(Symbol) && Symbol.iterator;
+const ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && isFunction(Symbol) && Symbol.iterator;
 const OLD_ITERATOR_SYMBOL = '@@iterator';
 
 /**
@@ -10,7 +10,7 @@ const OLD_ITERATOR_SYMBOL = '@@iterator';
 export default (maybeIterable: any): boolean => {
   let iterator;
 
-  if (!_.isObject(maybeIterable)) {
+  if (!isObject(maybeIterable)) {
     return false;
   }
 
@@ -20,5 +20,5 @@ export default (maybeIterable: any): boolean => {
     iterator = maybeIterable[OLD_ITERATOR_SYMBOL];
   }
 
-  return _.isFunction(iterator);
+  return isFunction(iterator);
 };

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -1,8 +1,8 @@
-import _ from 'lodash';
 import React, {
     ReactElement
 } from 'react';
 import objectUnfreeze from 'object-unfreeze';
+import {isArray, isObject} from './util';
 import isIterable from './isIterable';
 import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
@@ -26,7 +26,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
 
   if (React.isValidElement(elementShallowCopy.props.children)) {
     elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, configuration);
-  } else if (_.isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
+  } else if (isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
     elementShallowCopy.props.children = React.Children.map(elementShallowCopy.props.children, (node) => {
       if (React.isValidElement(node)) {
         return linkElement(node, styles, configuration);
@@ -65,7 +65,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
  */
 export default (element: ReactElement, styles = {}, configuration = {}): ReactElement => {
     // @see https://github.com/gajus/react-css-modules/pull/30
-  if (!_.isObject(element)) {
+  if (!isObject(element)) {
     return element;
   }
 

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import {isObject, isBoolean} from './util';
 
 /**
  * @typedef CSSModules~Options
@@ -17,17 +17,21 @@ export default (userConfiguration = {}) => {
     errorWhenNotFound: true
   };
 
-  _.forEach(userConfiguration, (value, name) => {
-    if (_.isUndefined(configuration[name])) {
-      throw new Error('Unknown configuration property "' + name + '".');
-    }
+  if (isObject(userConfiguration)) {
+    Object.keys(userConfiguration).forEach((name) => {
+      const value = userConfiguration[name];
 
-    if (!_.isBoolean(value)) {
-      throw new Error('"' + name + '" property value must be a boolean.');
-    }
+      if (configuration[name] === undefined) { // eslint-disable-line no-undefined
+        throw new Error('Unknown configuration property "' + name + '".');
+      }
 
-    configuration[name] = value;
-  });
+      if (!isBoolean(value)) {
+        throw new Error('"' + name + '" property value must be a boolean.');
+      }
+
+      configuration[name] = value;
+    });
+  }
 
   return configuration;
 };

--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 const styleNameIndex = {};
 
 export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<string> => {
@@ -8,8 +6,9 @@ export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<s
   if (styleNameIndex[styleNamePropertyValue]) {
     styleNames = styleNameIndex[styleNamePropertyValue];
   } else {
-    styleNames = _.trim(styleNamePropertyValue).split(' ');
-    styleNames = _.filter(styleNames);
+    styleNames = String(styleNamePropertyValue).trim().split(' ').filter((str) => {
+      return str;
+    });
 
     styleNameIndex[styleNamePropertyValue] = styleNames;
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,45 @@
+export const isObject = (obj) => {
+  return obj && typeof obj === 'object';
+};
+export const isFunction = (fn) => {
+  return fn instanceof Function;
+};
+export const isArray = (arr) => {
+  return arr instanceof Array;
+};
+export const isBoolean = (bool) => {
+  return typeof bool === 'boolean';
+};
+
+let ref;
+
+if (Object.assign && isFunction(Object.assign)) {
+  // If Object.assign exists use it
+  ref = Object.assign;
+} else {
+  // else use Polyfill
+  // Based on: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+  ref = function (...args) {
+    const target = args[0];
+
+    if (target === undefined || target === null) { // eslint-disable-line no-undefined
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+    const output = Object(target);
+
+    args.slice(1).forEach((src) => {
+      if (!isObject(src)) {
+        return;
+      }
+      Object.keys(src)
+      .forEach((key) => {
+        return src.hasOwnProperty(key) && (output[key] = src[key]);
+      });
+    });
+
+    return output;
+  };
+}
+const assign = ref;
+
+export {assign};

--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
-import _ from 'lodash';
 import React from 'react';
+import {isObject, assign} from './util';
 import linkClass from './linkClass';
 
 /**
@@ -15,10 +15,11 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
     if (props.styles) {
       useProps = props;
       styles = props.styles;
-    } else if (_.isObject(defaultStyles)) {
-      useProps = _.assign({}, props, {
+    } else if (isObject(defaultStyles)) {
+      useProps = {
+        ...props,
         styles: defaultStyles
-      });
+      };
 
       Object.defineProperty(useProps, 'styles', {
         configurable: true,
@@ -42,7 +43,7 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
     return React.createElement('noscript');
   };
 
-  _.assign(WrappedComponent, Component);
+  assign(WrappedComponent, Component);
 
   return WrappedComponent;
 };

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -123,6 +123,7 @@ describe('linkClass', () => {
           0: <p key='1' styleName='foo' />,
           1: <p key='2' styleName='bar' />,
           length: 2,
+
           // eslint-disable-next-line no-use-extend-native/no-use-extend-native
           [Symbol.iterator]: Array.prototype[Symbol.iterator]
         };

--- a/tests/reactCssModules.js
+++ b/tests/reactCssModules.js
@@ -138,7 +138,7 @@ describe('reactCssModules', () => {
     });
   });
   context('rendering element', () => {
-    beforeEach(() => {
+    beforeEach(() => { // eslint-disable-line mocha/no-hooks-for-single-case
       global.document = jsdom.jsdom('<!DOCTYPE html><html><head></head><body></body></html>');
 
       global.window = document.defaultView;

--- a/tests/wrapStatelessFunction.js
+++ b/tests/wrapStatelessFunction.js
@@ -13,7 +13,7 @@ describe('wrapStatelessFunction', () => {
       foo: 'foo-1'
     };
 
-    const Component = function InnerComponent () {
+    const Component = function () {
       return null;
     };
 


### PR DESCRIPTION
While I love the utility of lodash, particularly on the server, I think a 100kB+ dependency is a bit excessive to do simple type checking in the browser.  I added some simple functions which use basic javascript facilities to do the type checks you wanted.  There is the possibility of copying the methods more directly from lodash but I really would think these are sufficient.

I also added a few transforms for convenience to use instead of Object.assign (though you could still use Object.assign there).