### PR TITLE
Themes (styles overriding) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 coverage
-dist
+
 *.log
 .*
 !.README

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 tests
 coverage
 .*

--- a/dist/SimpleMap.js
+++ b/dist/SimpleMap.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _class = function () {
+  function _class() {
+    _classCallCheck(this, _class);
+
+    this.size = 0;
+    this.keys = [];
+    this.values = [];
+  }
+
+  _class.prototype.get = function get(key) {
+    var index = this.keys.indexOf(key);
+
+    return this.values[index];
+  };
+
+  _class.prototype.set = function set(key, value) {
+    this.keys.push(key);
+    this.values.push(value);
+    this.size = this.keys.length;
+
+    return value;
+  };
+
+  return _class;
+}();
+
+exports.default = _class;
+module.exports = exports["default"];

--- a/dist/extendReactClass.js
+++ b/dist/extendReactClass.js
@@ -1,0 +1,98 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isObject2 = require('lodash/isObject');
+
+var _isObject3 = _interopRequireDefault(_isObject2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _hoistNonReactStatics = require('hoist-non-react-statics');
+
+var _hoistNonReactStatics2 = _interopRequireDefault(_hoistNonReactStatics);
+
+var _linkClass = require('./linkClass');
+
+var _linkClass2 = _interopRequireDefault(_linkClass);
+
+var _renderNothing = require('./renderNothing');
+
+var _renderNothing2 = _interopRequireDefault(_renderNothing);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : _defaults(subClass, superClass); } /* eslint-disable react/prop-types */
+
+/**
+ * @param {ReactClass} Component
+ * @param {Object} defaultStyles
+ * @param {Object} options
+ * @returns {ReactClass}
+ */
+exports.default = function (Component, defaultStyles, options) {
+  var WrappedComponent = function (_Component) {
+    _inherits(WrappedComponent, _Component);
+
+    function WrappedComponent() {
+      _classCallCheck(this, WrappedComponent);
+
+      return _possibleConstructorReturn(this, _Component.apply(this, arguments));
+    }
+
+    WrappedComponent.prototype.render = function render() {
+      var propsChanged = void 0;
+      var styles = void 0;
+
+      propsChanged = false;
+
+      if (this.props.styles) {
+        styles = this.props.styles;
+      } else if ((0, _isObject3.default)(defaultStyles)) {
+        var props = Object.assign({}, this.props);
+
+        Object.defineProperty(props, 'styles', {
+          configurable: true,
+          enumerable: false,
+          value: defaultStyles,
+          writable: false
+        });
+
+        this.props = props;
+
+        propsChanged = true;
+        styles = defaultStyles;
+      } else {
+        styles = {};
+      }
+
+      var renderResult = _Component.prototype.render.call(this);
+
+      if (propsChanged) {
+        delete this.props.styles;
+      }
+
+      if (renderResult) {
+        return (0, _linkClass2.default)(renderResult, styles, this.props.themes, options);
+      }
+
+      return (0, _renderNothing2.default)(_react2.default.version);
+    };
+
+    return WrappedComponent;
+  }(Component);
+
+  return (0, _hoistNonReactStatics2.default)(WrappedComponent, Component);
+};
+
+module.exports = exports['default'];

--- a/dist/generateAppendClassName.js
+++ b/dist/generateAppendClassName.js
@@ -1,0 +1,51 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var CustomMap = _immutable2.default.Map;
+
+var stylesIndex = new CustomMap();
+
+exports.default = function (styles, themes, styleNames, errorWhenNotFound) {
+  var appendClassName = void 0;
+  var stylesIndexMap = void 0;
+
+  var styleNameIndex = stylesIndex.getIn([styles, themes, styleNames]);
+  if (styleNameIndex) {
+    return styleNameIndex;
+  }
+
+  appendClassName = '';
+
+  for (var styleName in styleNames) {
+    if (styleNames.hasOwnProperty(styleName)) {
+      var key = styleNames[styleName];
+      var className = themes[key];
+      if (className == undefined) {
+        className = styles[key];
+      }
+
+      if (className) {
+        appendClassName += ' ' + className;
+      } else if (errorWhenNotFound === true) {
+        throw new Error('"' + styleNames[styleName] + '" CSS module is undefined.');
+      }
+    }
+  }
+
+  appendClassName = appendClassName.trim();
+
+  stylesIndex = stylesIndex.setIn([styles, themes, styleNames], appendClassName);
+
+  return appendClassName;
+};
+
+module.exports = exports['default'];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,77 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isFunction2 = require('lodash/isFunction');
+
+var _isFunction3 = _interopRequireDefault(_isFunction2);
+
+var _extendReactClass = require('./extendReactClass');
+
+var _extendReactClass2 = _interopRequireDefault(_extendReactClass);
+
+var _wrapStatelessFunction = require('./wrapStatelessFunction');
+
+var _wrapStatelessFunction2 = _interopRequireDefault(_wrapStatelessFunction);
+
+var _makeConfiguration = require('./makeConfiguration');
+
+var _makeConfiguration2 = _interopRequireDefault(_makeConfiguration);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Determines if the given object has the signature of a class that inherits React.Component.
+ */
+
+
+/**
+ * @see https://github.com/gajus/react-css-modules#options
+ */
+var isReactComponent = function isReactComponent(maybeReactComponent) {
+  return 'prototype' in maybeReactComponent && (0, _isFunction3.default)(maybeReactComponent.prototype.render);
+};
+
+/**
+ * When used as a function.
+ */
+var functionConstructor = function functionConstructor(Component, defaultStyles, options) {
+  var decoratedClass = void 0;
+
+  var configuration = (0, _makeConfiguration2.default)(options);
+
+  if (isReactComponent(Component)) {
+    decoratedClass = (0, _extendReactClass2.default)(Component, defaultStyles, configuration);
+  } else {
+    decoratedClass = (0, _wrapStatelessFunction2.default)(Component, defaultStyles, configuration);
+  }
+
+  if (Component.displayName) {
+    decoratedClass.displayName = Component.displayName;
+  } else {
+    decoratedClass.displayName = Component.name;
+  }
+
+  return decoratedClass;
+};
+
+/**
+ * When used as a ES7 decorator.
+ */
+var decoratorConstructor = function decoratorConstructor(defaultStyles, options) {
+  return function (Component) {
+    return functionConstructor(Component, defaultStyles, options);
+  };
+};
+
+exports.default = function () {
+  if ((0, _isFunction3.default)(arguments.length <= 0 ? undefined : arguments[0])) {
+    return functionConstructor(arguments.length <= 0 ? undefined : arguments[0], arguments.length <= 1 ? undefined : arguments[1], arguments.length <= 2 ? undefined : arguments[2]);
+  } else {
+    return decoratorConstructor(arguments.length <= 0 ? undefined : arguments[0], arguments.length <= 1 ? undefined : arguments[1]);
+  }
+};
+
+module.exports = exports['default'];

--- a/dist/isIterable.js
+++ b/dist/isIterable.js
@@ -1,0 +1,41 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isObject2 = require('lodash/isObject');
+
+var _isObject3 = _interopRequireDefault(_isObject2);
+
+var _isFunction2 = require('lodash/isFunction');
+
+var _isFunction3 = _interopRequireDefault(_isFunction2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var ITERATOR_SYMBOL = typeof Symbol !== 'undefined' && (0, _isFunction3.default)(Symbol) && Symbol.iterator;
+var OLD_ITERATOR_SYMBOL = '@@iterator';
+
+/**
+ * @see https://github.com/lodash/lodash/issues/1668
+ * @see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols
+ */
+
+exports.default = function (maybeIterable) {
+  var iterator = void 0;
+
+  if (!(0, _isObject3.default)(maybeIterable)) {
+    return false;
+  }
+
+  if (ITERATOR_SYMBOL) {
+    iterator = maybeIterable[ITERATOR_SYMBOL];
+  } else {
+    iterator = maybeIterable[OLD_ITERATOR_SYMBOL];
+  }
+
+  return (0, _isFunction3.default)(iterator);
+};
+
+module.exports = exports['default'];

--- a/dist/linkClass.js
+++ b/dist/linkClass.js
@@ -1,0 +1,107 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isObject2 = require('lodash/isObject');
+
+var _isObject3 = _interopRequireDefault(_isObject2);
+
+var _isArray2 = require('lodash/isArray');
+
+var _isArray3 = _interopRequireDefault(_isArray2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _objectUnfreeze = require('object-unfreeze');
+
+var _objectUnfreeze2 = _interopRequireDefault(_objectUnfreeze);
+
+var _isIterable = require('./isIterable');
+
+var _isIterable2 = _interopRequireDefault(_isIterable);
+
+var _parseStyleName = require('./parseStyleName');
+
+var _parseStyleName2 = _interopRequireDefault(_parseStyleName);
+
+var _generateAppendClassName = require('./generateAppendClassName');
+
+var _generateAppendClassName2 = _interopRequireDefault(_generateAppendClassName);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var linkElement = function linkElement(element, styles, themes, configuration) {
+  var appendClassName = void 0;
+  var elementIsFrozen = void 0;
+  var elementShallowCopy = void 0;
+
+  elementShallowCopy = element;
+
+  if (Object.isFrozen && Object.isFrozen(elementShallowCopy)) {
+    elementIsFrozen = true;
+
+    // https://github.com/facebook/react/blob/v0.13.3/src/classic/element/ReactElement.js#L131
+    elementShallowCopy = (0, _objectUnfreeze2.default)(elementShallowCopy);
+    elementShallowCopy.props = (0, _objectUnfreeze2.default)(elementShallowCopy.props);
+  }
+
+  var styleNames = (0, _parseStyleName2.default)(elementShallowCopy.props.styleName || '', configuration.allowMultiple);
+
+  if (_react2.default.isValidElement(elementShallowCopy.props.children)) {
+    elementShallowCopy.props.children = linkElement(_react2.default.Children.only(elementShallowCopy.props.children), styles, themes, configuration);
+  } else if ((0, _isArray3.default)(elementShallowCopy.props.children) || (0, _isIterable2.default)(elementShallowCopy.props.children)) {
+    elementShallowCopy.props.children = _react2.default.Children.map(elementShallowCopy.props.children, function (node) {
+      if (_react2.default.isValidElement(node)) {
+        return linkElement(node, styles, themes, configuration);
+      } else {
+        return node;
+      }
+    });
+  }
+
+  if (styleNames.length) {
+    appendClassName = (0, _generateAppendClassName2.default)(styles, themes, styleNames, configuration.errorWhenNotFound);
+
+    if (appendClassName) {
+      if (elementShallowCopy.props.className) {
+        appendClassName = elementShallowCopy.props.className + ' ' + appendClassName;
+      }
+
+      elementShallowCopy.props.className = appendClassName;
+    }
+  }
+
+  delete elementShallowCopy.props.styleName;
+
+  if (elementIsFrozen) {
+    Object.freeze(elementShallowCopy.props);
+    Object.freeze(elementShallowCopy);
+  }
+
+  return elementShallowCopy;
+};
+
+/**
+ * @param {ReactElement} element
+ * @param {Object} styles CSS modules class map.
+ * @param {CSSModules~Options} configuration
+ */
+
+exports.default = function (element) {
+  var styles = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var themes = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+  var configuration = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  // @see https://github.com/gajus/react-css-modules/pull/30
+  if (!(0, _isObject3.default)(element)) {
+    return element;
+  }
+
+  return linkElement(element, styles, themes, configuration);
+};
+
+module.exports = exports['default'];

--- a/dist/makeConfiguration.js
+++ b/dist/makeConfiguration.js
@@ -1,0 +1,55 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isBoolean2 = require('lodash/isBoolean');
+
+var _isBoolean3 = _interopRequireDefault(_isBoolean2);
+
+var _isUndefined2 = require('lodash/isUndefined');
+
+var _isUndefined3 = _interopRequireDefault(_isUndefined2);
+
+var _forEach2 = require('lodash/forEach');
+
+var _forEach3 = _interopRequireDefault(_forEach2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * @typedef CSSModules~Options
+ * @see {@link https://github.com/gajus/react-css-modules#options}
+ * @property {boolean} allowMultiple
+ * @property {boolean} errorWhenNotFound
+ */
+
+/**
+ * @param {CSSModules~Options} userConfiguration
+ * @returns {CSSModules~Options}
+ */
+exports.default = function () {
+  var userConfiguration = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  var configuration = {
+    allowMultiple: false,
+    errorWhenNotFound: true
+  };
+
+  (0, _forEach3.default)(userConfiguration, function (value, name) {
+    if ((0, _isUndefined3.default)(configuration[name])) {
+      throw new Error('Unknown configuration property "' + name + '".');
+    }
+
+    if (!(0, _isBoolean3.default)(value)) {
+      throw new Error('"' + name + '" property value must be a boolean.');
+    }
+
+    configuration[name] = value;
+  });
+
+  return configuration;
+};
+
+module.exports = exports['default'];

--- a/dist/parseStyleName.js
+++ b/dist/parseStyleName.js
@@ -1,0 +1,38 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _filter2 = require('lodash/filter');
+
+var _filter3 = _interopRequireDefault(_filter2);
+
+var _trim2 = require('lodash/trim');
+
+var _trim3 = _interopRequireDefault(_trim2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var styleNameIndex = {};
+
+exports.default = function (styleNamePropertyValue, allowMultiple) {
+  var styleNames = void 0;
+
+  if (styleNameIndex[styleNamePropertyValue]) {
+    styleNames = styleNameIndex[styleNamePropertyValue];
+  } else {
+    styleNames = (0, _trim3.default)(styleNamePropertyValue).split(' ');
+    styleNames = (0, _filter3.default)(styleNames);
+
+    styleNameIndex[styleNamePropertyValue] = styleNames;
+  }
+
+  if (allowMultiple === false && styleNames.length > 1) {
+    throw new Error('ReactElement styleName property defines multiple module names ("' + styleNamePropertyValue + '").');
+  }
+
+  return styleNames;
+};
+
+module.exports = exports['default'];

--- a/dist/renderNothing.js
+++ b/dist/renderNothing.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function (version) {
+  var major = version.split('.')[0];
+
+  return parseInt(major, 10) < 15 ? _react2.default.createElement('noscript') : null;
+};
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = exports['default'];

--- a/dist/wrapStatelessFunction.js
+++ b/dist/wrapStatelessFunction.js
@@ -1,0 +1,78 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _assign2 = require('lodash/assign');
+
+var _assign3 = _interopRequireDefault(_assign2);
+
+var _isObject2 = require('lodash/isObject');
+
+var _isObject3 = _interopRequireDefault(_isObject2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _linkClass = require('./linkClass');
+
+var _linkClass2 = _interopRequireDefault(_linkClass);
+
+var _renderNothing = require('./renderNothing');
+
+var _renderNothing2 = _interopRequireDefault(_renderNothing);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * @see https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
+ */
+exports.default = function (Component, defaultStyles, options) {
+  var WrappedComponent = function WrappedComponent() {
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+    var styles = void 0;
+    var useProps = void 0;
+
+    if (props.styles) {
+      useProps = props;
+      styles = props.styles;
+    } else if ((0, _isObject3.default)(defaultStyles)) {
+      useProps = (0, _assign3.default)({}, props, {
+        styles: defaultStyles
+      });
+
+      Object.defineProperty(useProps, 'styles', {
+        configurable: true,
+        enumerable: false,
+        value: defaultStyles,
+        writable: false
+      });
+
+      styles = defaultStyles;
+    } else {
+      useProps = props;
+      styles = {};
+    }
+
+    var renderResult = Component.apply(undefined, [useProps].concat(args));
+
+    if (renderResult) {
+      return (0, _linkClass2.default)(renderResult, styles, props.themes, options);
+    }
+
+    return (0, _renderNothing2.default)(_react2.default.version);
+  };
+
+  (0, _assign3.default)(WrappedComponent, Component);
+
+  return WrappedComponent;
+}; /* eslint-disable react/prop-types */
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
   "scripts": {
     "lint": "eslint ./src ./tests",
     "test": "NODE_ENV=development mocha --compilers js:babel-register ./tests/**/*.js && npm run lint && npm run build",
-    "build": "NODE_ENV=production babel ./src --out-dir ./dist",
-    "precommit": "npm run test",
-    "install": "npm run build"
+    "build": "NODE_ENV=production babel ./src --out-dir ./dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "hoist-non-react-statics": "^1.2.0",
     "lodash": "^4.16.6",
-    "object-unfreeze": "^1.1.0"
+    "object-unfreeze": "^1.1.0",
+    "immutable": "*"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -49,6 +50,7 @@
     "lint": "eslint ./src ./tests",
     "test": "NODE_ENV=development mocha --compilers js:babel-register ./tests/**/*.js && npm run lint && npm run build",
     "build": "NODE_ENV=production babel ./src --out-dir ./dist",
-    "precommit": "npm run test"
+    "precommit": "npm run test",
+    "install": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "hoist-non-react-statics": "^1.2.0",
     "lodash": "^4.16.6",
     "object-unfreeze": "^1.1.0",
-    "immutable": "*"
+    "immutable": "*",
+    "babel-cli": "^6.18.0"    
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -47,7 +47,7 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
       }
 
       if (renderResult) {
-        return linkClass(renderResult, styles, options);
+        return linkClass(renderResult, styles, this.props.themes, options);
       }
 
       return renderNothing(React.version);

--- a/src/generateAppendClassName.js
+++ b/src/generateAppendClassName.js
@@ -1,32 +1,28 @@
-import SimpleMap from './SimpleMap';
+import Immutable from 'immutable';
 
-const CustomMap = typeof Map === 'undefined' ? SimpleMap : Map;
+const CustomMap = Immutable.Map;
 
-const stylesIndex = new CustomMap();
+let stylesIndex = new CustomMap();
 
-export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): string => {
+export default (styles, themes, styleNames: Array<string>, errorWhenNotFound: boolean): string => {
   let appendClassName;
   let stylesIndexMap;
 
-  stylesIndexMap = stylesIndex.get(styles);
-
-  if (stylesIndexMap) {
-    const styleNameIndex = stylesIndexMap.get(styleNames);
-
-    if (styleNameIndex) {
-      return styleNameIndex;
-    }
-  } else {
-    stylesIndexMap = new CustomMap();
-    stylesIndex.set(styles, new CustomMap());
+  const styleNameIndex = stylesIndex.getIn([styles, themes, styleNames]);
+  if (styleNameIndex) {
+    return styleNameIndex;
   }
-
+  
   appendClassName = '';
 
   for (const styleName in styleNames) {
     if (styleNames.hasOwnProperty(styleName)) {
-      const className = styles[styleNames[styleName]];
-
+      const key = styleNames[styleName];
+      let className = themes[key];
+      if (className == undefined) {
+        className = styles[key];
+      }
+      
       if (className) {
         appendClassName += ' ' + className;
       } else if (errorWhenNotFound === true) {
@@ -37,7 +33,7 @@ export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): 
 
   appendClassName = appendClassName.trim();
 
-  stylesIndexMap.set(styleNames, appendClassName);
+  stylesIndex = stylesIndex.setIn([styles, themes, styleNames], appendClassName);
 
   return appendClassName;
 };

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -7,7 +7,7 @@ import isIterable from './isIterable';
 import parseStyleName from './parseStyleName';
 import generateAppendClassName from './generateAppendClassName';
 
-const linkElement = (element: ReactElement, styles: Object, configuration: Object): ReactElement => {
+const linkElement = (element: ReactElement, styles: Object, themes: Object, configuration: Object): ReactElement => {
   let appendClassName;
   let elementIsFrozen;
   let elementShallowCopy;
@@ -25,11 +25,11 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   const styleNames = parseStyleName(elementShallowCopy.props.styleName || '', configuration.allowMultiple);
 
   if (React.isValidElement(elementShallowCopy.props.children)) {
-    elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, configuration);
+    elementShallowCopy.props.children = linkElement(React.Children.only(elementShallowCopy.props.children), styles, themes, configuration);
   } else if (_.isArray(elementShallowCopy.props.children) || isIterable(elementShallowCopy.props.children)) {
     elementShallowCopy.props.children = React.Children.map(elementShallowCopy.props.children, (node) => {
       if (React.isValidElement(node)) {
-        return linkElement(node, styles, configuration);
+        return linkElement(node, styles, themes, configuration);
       } else {
         return node;
       }
@@ -37,7 +37,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   }
 
   if (styleNames.length) {
-    appendClassName = generateAppendClassName(styles, styleNames, configuration.errorWhenNotFound);
+    appendClassName = generateAppendClassName(styles, themes, styleNames, configuration.errorWhenNotFound);
 
     if (appendClassName) {
       if (elementShallowCopy.props.className) {
@@ -63,11 +63,11 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
  * @param {Object} styles CSS modules class map.
  * @param {CSSModules~Options} configuration
  */
-export default (element: ReactElement, styles = {}, configuration = {}): ReactElement => {
+export default (element: ReactElement, styles = {}, themes = {}, configuration = {}): ReactElement => {
     // @see https://github.com/gajus/react-css-modules/pull/30
   if (!_.isObject(element)) {
     return element;
   }
 
-  return linkElement(element, styles, configuration);
+  return linkElement(element, styles, themes, configuration);
 };

--- a/src/wrapStatelessFunction.js
+++ b/src/wrapStatelessFunction.js
@@ -37,7 +37,7 @@ export default (Component: Function, defaultStyles: Object, options: Object): Fu
     const renderResult = Component(useProps, ...args);
 
     if (renderResult) {
-      return linkClass(renderResult, styles, options);
+      return linkClass(renderResult, styles, props.themes, options);
     }
 
     return renderNothing(React.version);


### PR DESCRIPTION
Currently if we want to override several classes for component we need to write
```js
const CustomDropdownStyles = _.merge({}, DefaultDropdownStyles, { input: Styles.myInput })

render() {
  return <Dropdown styles={CustomDropdownStyles} />
}
```
With this PR it's possible to write

```js
render() {
    return <Dropdown themes={input: Styles.myInput}/>
}
```
I could replace `themes` by more abvious name, like `stylesToOverride`
