### PR TITLE
Support react components with "render" as a property

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -14,7 +14,14 @@ import renderNothing from './renderNothing';
  */
 export default (Component: Object, defaultStyles: Object, options: Object) => {
   const WrappedComponent = class extends Component {
-    render () {
+    constructor () {
+      super();
+
+      this.componentRender = this.render.bind(this);
+      this.render = this.wrappedRender;
+    }
+
+    wrappedRender () {
       let propsChanged;
       let styles;
 
@@ -40,7 +47,7 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
         styles = {};
       }
 
-      const renderResult = super.render();
+      const renderResult = this.componentRender();
 
       if (propsChanged) {
         delete this.props.styles;

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,17 @@ import makeConfiguration from './makeConfiguration';
 type TypeOptions = {};
 
 /**
+ * Determinse if the first argument is Object.
+ */
+const isObject = (maybeObject: any): boolean => {
+  return Object.prototype.toString.call(maybeObject) === '[object Object]';
+};
+
+/**
  * Determines if the given object has the signature of a class that inherits React.Component.
  */
 const isReactComponent = (maybeReactComponent: any): boolean => {
-  return 'prototype' in maybeReactComponent && _.isFunction(maybeReactComponent.prototype.render);
+  return 'prototype' in maybeReactComponent && isObject(maybeReactComponent.prototype.isReactComponent);
 };
 
 /**

--- a/tests/reactCssModules.js
+++ b/tests/reactCssModules.js
@@ -64,6 +64,34 @@ describe('reactCssModules', () => {
         expect(component.props).not.to.have.property('styleName');
       });
     });
+    context('the component is a class that extends React.Component with "render" as a property', () => {
+      let Foo;
+      let component;
+
+      beforeEach(() => {
+        const shallowRenderer = TestUtils.createRenderer();
+
+        Foo = class extends React.Component {
+          render = () => {
+            return <div styleName='foo'>Hello</div>;
+          }
+        };
+
+        Foo = reactCssModules(Foo, {
+          foo: 'foo-1'
+        });
+
+        shallowRenderer.render(<Foo />);
+
+        component = shallowRenderer.getRenderOutput();
+      });
+      it('that element should contain the equivalent className', () => {
+        expect(component.props.className).to.equal('foo-1');
+      });
+      it('the styleName prop should be "consumed" in the process', () => {
+        expect(component.props).not.to.have.property('styleName');
+      });
+    });
     context('the component is a stateless function component', () => {
       let Foo;
       let component;


### PR DESCRIPTION
## Why

Some users can write `render` method as a property:

```jsx
class Component extends React.Component {
  render = () => (
    <div>Test component</div>
  )
}
```

Full discussion in #204

## Known issues

I changed `isReactComponent` function and now it's based on not documented part of code: https://github.com/facebook/react/blob/d47a3a36ee9de36cf32cd9233f923ced07b5d79d/src/isomorphic/modern/class/ReactComponent.js#L33

Need to figure out when it was added to React and what was there before. But firstly I'd like to see your opinion about such changes in this repository.