### PR TITLE
Fixed insufficient splitting of styleName attribute content

### DIFF
--- a/src/parseStyleName.js
+++ b/src/parseStyleName.js
@@ -8,7 +8,7 @@ export default (styleNamePropertyValue: string, allowMultiple: boolean): Array<s
   if (styleNameIndex[styleNamePropertyValue]) {
     styleNames = styleNameIndex[styleNamePropertyValue];
   } else {
-    styleNames = _.trim(styleNamePropertyValue).split(' ');
+    styleNames = _.trim(styleNamePropertyValue).split(/\s+/);
     styleNames = _.filter(styleNames);
 
     styleNameIndex[styleNamePropertyValue] = styleNames;


### PR DESCRIPTION
Currently it is impossible to use delimiters in styleName other than a single space symbol. The change allows to use any whitespace characters, such as a newline character which is handy if you use multiple class names in a single styleName attribute combined with ES6 string literal.

## Motivation
We are using BEM along with `react-css-modules` (because we are not yet decided if we are ready to abandon BEM in favor of CSS Modules). So we have multiple and pretty long string in styleName and ES6 string literal come to rescue here because it allows to write it multiline (also string templates make it easier to write modifiers). Unfortunately we can't use this nifty feature, because the styleName parser recognizes a newline character as a part of a class name which leads to conflicts between code and stylesheets thus we have to write styleName strings of hundreds colons wide.