### PR TITLE
Remove note about camelCase styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Awesome!
 
 webpack [css-loader](https://github.com/webpack/css-loader#css-modules) itself has several disadvantages:
 
-* You have to use `camelCase` CSS class names.
 * You have to use `styles` object whenever constructing a `className`.
 * Mixing CSS Modules and global CSS classes is cumbersome.
 * Reference to an undefined CSS Module resolves to `undefined` without a warning.


### PR DESCRIPTION
Just a small nit, this isn't actually true anymore (for a while?) `css-loader` has an option to convert classes to camelCase, so you can write: `.foo-bar { }` and reference as `styles.fooBar`