### PR TITLE
Update ExtractTextPlugin v2x setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Setup:
     {
       test: /\.css$/,
       loader: ExtractTextPlugin.extract({
-          notExtractLoader: 'style-loader',
-          loader: 'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]!resolve-url!postcss',
+          fallback: 'style-loader',
+          use: 'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]!resolve-url!postcss',
       }),
     }
     ```


### PR DESCRIPTION
Source: https://github.com/webpack-contrib/extract-text-webpack-plugin#usage

Otherwise error will be thrown: 

```
<path to project>/client/node_modules/extract-text-webpack-plugin/schema/validator.js:11
		throw new Error(ajv.errorsText());
		^

Error: data['notExtractLoader'] should NOT have additional properties
```