### PR TITLE
implement warningWhenNotFound option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ React CSS Modules implement automatic mapping of CSS modules. Every CSS class is
     - [Options](#options)
         - [`allowMultiple`](#allowmultiple)
         - [`errorWhenNotFound`](#errorwhennotfound)
+        - [`warningWhenNotFound`](#warningwhennotfound)
 - [SASS, SCSS, LESS and other CSS Preprocessors](#sass-scss-less-and-other-css-preprocessors)
     - [Enable Sourcemaps](#enable-sourcemaps)
 - [Class Composition](#class-composition)
@@ -409,6 +410,7 @@ export default CSSModules(CustomList, styles);
  * @see {@link https://github.com/gajus/react-css-modules#options}
  * @property {Boolean} allowMultiple
  * @property {Boolean} errorWhenNotFound
+ * @property {Boolean} warningWhenNotFound
  */
 
 /**
@@ -497,6 +499,12 @@ When `false`, the following will cause an error:
 Default: `true`.
 
 Throws an error when `styleName` cannot be mapped to an existing CSS Module.
+
+#### `warningWhenNotFound`
+
+Default: `false`.
+
+Outputs a warning when `styleName` cannot be mapped to an existing CSS Module.
 
 ## SASS, SCSS, LESS and other CSS Preprocessors
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
     "chai": "^4.0.0-canary.1",
+    "chai-spies": "^0.7.1",
     "eslint": "^3.10.0",
     "eslint-config-canonical": "^5.5.0",
     "husky": "^0.11.9",

--- a/src/generateAppendClassName.js
+++ b/src/generateAppendClassName.js
@@ -4,7 +4,7 @@ const CustomMap = typeof Map === 'undefined' ? SimpleMap : Map;
 
 const stylesIndex = new CustomMap();
 
-export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): string => {
+export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean, warningWhenNotFound: boolean): string => {
   let appendClassName;
   let stylesIndexMap;
 
@@ -29,8 +29,14 @@ export default (styles, styleNames: Array<string>, errorWhenNotFound: boolean): 
 
       if (className) {
         appendClassName += ' ' + className;
-      } else if (errorWhenNotFound === true) {
-        throw new Error('"' + styleNames[styleName] + '" CSS module is undefined.');
+      } else {
+        if (errorWhenNotFound === true) {
+          throw new Error('"' + styleNames[styleName] + '" CSS module is undefined.');
+        }
+        if (warningWhenNotFound === true) {
+          // eslint-disable-next-line no-console
+          console.warn('"' + styleNames[styleName] + '" CSS module is undefined.');
+        }
       }
     }
   }

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -68,7 +68,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   });
 
   if (styleNames.length) {
-    appendClassName = generateAppendClassName(styles, styleNames, configuration.errorWhenNotFound);
+    appendClassName = generateAppendClassName(styles, styleNames, configuration.errorWhenNotFound, configuration.warningWhenNotFound);
 
     if (appendClassName) {
       if (elementShallowCopy.props.className) {

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
  * @see {@link https://github.com/gajus/react-css-modules#options}
  * @property {boolean} allowMultiple
  * @property {boolean} errorWhenNotFound
+ * @property {boolean} warningWhenNotFound
  */
 
 /**
@@ -14,7 +15,8 @@ import _ from 'lodash';
 export default (userConfiguration = {}) => {
   const configuration = {
     allowMultiple: false,
-    errorWhenNotFound: true
+    errorWhenNotFound: true,
+    warningWhenNotFound: false
   };
 
   _.forEach(userConfiguration, (value, name) => {

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -1,12 +1,15 @@
-/* eslint-disable max-nested-callbacks, react/prefer-stateless-function, class-methods-use-this */
+/* eslint-disable max-nested-callbacks, react/prefer-stateless-function, class-methods-use-this, no-console */
 
-import {
+import chai, {
     expect
 } from 'chai';
+import spies from 'chai-spies';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import jsdom from 'jsdom';
 import linkClass from './../src/linkClass';
+
+chai.use(spies);
 
 describe('linkClass', () => {
   context('ReactElement does not define styleName', () => {
@@ -282,6 +285,32 @@ describe('linkClass', () => {
           expect(() => {
             linkClass(<div styleName='foo' />, {}, {errorWhenNotFound: true});
           }).to.throw(Error, '"foo" CSS module is undefined.');
+        });
+      });
+    });
+  });
+
+  describe('options.warningWhenNotFound', () => {
+    context('when styleName does not match an existing CSS module', () => {
+      const warnSpy = chai.spy(() => {});
+
+      console.warn = warnSpy;
+      context('when false', () => {
+        it('does not throw a warning when there\'s a missing CSS module', () => {
+          let subject;
+
+          subject = <div styleName='foo' />;
+
+          subject = linkClass(subject, {}, {warningWhenNotFound: false});
+
+          expect(subject.props.className).to.be.an('undefined');
+          expect(warnSpy).to.not.have.been.called();
+        });
+      });
+      context('when is true', () => {
+        it('throws a warning', () => {
+          linkClass(<div styleName='foo' />, {}, {warningWhenNotFound: true});
+          expect(warnSpy).to.have.been.called();
         });
       });
     });

--- a/tests/makeConfiguration.js
+++ b/tests/makeConfiguration.js
@@ -22,6 +22,11 @@ describe('makeConfiguration', () => {
         expect(configuration.errorWhenNotFound).to.equal(true);
       });
     });
+    describe('warningWhenNotFound property', () => {
+      it('defaults to false', () => {
+        expect(configuration.warningWhenNotFound).to.equal(false);
+      });
+    });
   });
   describe('when unknown property is provided', () => {
     it('throws an error', () => {


### PR DESCRIPTION
This implements what was suggested in #209. I'm still not 100% buying how the two options interact with each other since you have to manually disable `errorWhenNotFound` and enable `warningWhenNotFound`. Ideally I would like to have a way to specify the log level when a class is not found, but maybe keeping backwards compatibility is more valuable and we can afford this redundancy. Thoughts?