### PR TITLE
Fix React 16 issues

### DIFF
--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -26,11 +26,16 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   let elementShallowCopy;
 
   elementShallowCopy = element;
+  elementIsFrozen = Object.isFrozen && (
+    Object.isFrozen(elementShallowCopy) ||
+    Object.isFrozen(elementShallowCopy.props)
+  ) || Object.isExtensible && (
+    !Object.isExtensible(elementShallowCopy) ||
+    !Object.isExtensible(elementShallowCopy.props)
+  );
 
-  if (Object.isFrozen && Object.isFrozen(elementShallowCopy)) {
-    elementIsFrozen = true;
-
-        // https://github.com/facebook/react/blob/v0.13.3/src/classic/element/ReactElement.js#L131
+  if (elementIsFrozen) {
+    // https://github.com/facebook/react/blob/v0.13.3/src/classic/element/ReactElement.js#L131
     elementShallowCopy = objectUnfreeze(elementShallowCopy);
     elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
   }

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -27,13 +27,14 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   elementShallowCopy = element;
 
   const elementIsFrozen = Object.isFrozen && Object.isFrozen(elementShallowCopy);
+  const propsFrozen = Object.isFrozen && Object.isFrozen(elementShallowCopy.props);
   const propsNotExtensible = Object.isExtensible && !Object.isExtensible(elementShallowCopy.props);
 
   if (elementIsFrozen) {
     // https://github.com/facebook/react/blob/v0.13.3/src/classic/element/ReactElement.js#L131
     elementShallowCopy = objectUnfreeze(elementShallowCopy);
     elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
-  } else if (propsNotExtensible) {
+  } else if (propsFrozen || propsNotExtensible) {
     elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
   }
 
@@ -78,6 +79,8 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   if (elementIsFrozen) {
     Object.freeze(elementShallowCopy.props);
     Object.freeze(elementShallowCopy);
+  } else if (propsFrozen) {
+    Object.freeze(elementShallowCopy.props);
   }
 
   if (propsNotExtensible) {

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -22,21 +22,18 @@ const linkArray = (array: Array, styles: Object, configuration: Object) => {
 
 const linkElement = (element: ReactElement, styles: Object, configuration: Object): ReactElement => {
   let appendClassName;
-  let elementIsFrozen;
   let elementShallowCopy;
 
   elementShallowCopy = element;
-  elementIsFrozen = Object.isFrozen && (
-    Object.isFrozen(elementShallowCopy) ||
-    Object.isFrozen(elementShallowCopy.props)
-  ) || Object.isExtensible && (
-    !Object.isExtensible(elementShallowCopy) ||
-    !Object.isExtensible(elementShallowCopy.props)
-  );
+
+  const elementIsFrozen = Object.isFrozen && Object.isFrozen(elementShallowCopy);
+  const propsNotExtensible = Object.isExtensible && !Object.isExtensible(elementShallowCopy.props);
 
   if (elementIsFrozen) {
     // https://github.com/facebook/react/blob/v0.13.3/src/classic/element/ReactElement.js#L131
     elementShallowCopy = objectUnfreeze(elementShallowCopy);
+    elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
+  } else if (propsNotExtensible) {
     elementShallowCopy.props = objectUnfreeze(elementShallowCopy.props);
   }
 
@@ -81,6 +78,10 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   if (elementIsFrozen) {
     Object.freeze(elementShallowCopy.props);
     Object.freeze(elementShallowCopy);
+  }
+
+  if (propsNotExtensible) {
+    Object.preventExtensions(elementShallowCopy.props);
   }
 
   return elementShallowCopy;

--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -26,6 +26,12 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
 
   elementShallowCopy = element;
 
+  if (Array.isArray(elementShallowCopy)) {
+    return elementShallowCopy.map((arrayElement) => {
+      return linkElement(arrayElement, styles, configuration);
+    });
+  }
+
   const elementIsFrozen = Object.isFrozen && Object.isFrozen(elementShallowCopy);
   const propsFrozen = Object.isFrozen && Object.isFrozen(elementShallowCopy.props);
   const propsNotExtensible = Object.isExtensible && !Object.isExtensible(elementShallowCopy.props);

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-nested-callbacks, react/prefer-stateless-function, class-methods-use-this, no-console */
+/* eslint-disable max-nested-callbacks, react/prefer-stateless-function, class-methods-use-this, no-console, no-unused-expressions */
 
 import chai, {
     expect
@@ -236,6 +236,76 @@ describe('linkClass', () => {
       });
 
       expect(subject.props.children.props.className).to.equal('foo-1 bar-1');
+    });
+  });
+
+  context('can\'t write to properties', () => {
+    context('when the element is frozen', () => {
+      it('adds className but is still frozen', () => {
+        let subject;
+
+        subject = <div styleName='foo' />;
+
+        Object.freeze(subject);
+        subject = linkClass(subject, {
+          foo: 'foo-1'
+        });
+
+        expect(subject).to.be.frozen;
+        expect(subject.props.className).to.equal('foo-1');
+      });
+    });
+    context('when the element\'s props are frozen', () => {
+      it('adds className and only props are still frozen', () => {
+        let subject;
+
+        subject = <div styleName='foo' />;
+
+        Object.freeze(subject.props);
+        subject = linkClass(subject, {
+          foo: 'foo-1'
+        });
+
+        expect(subject.props).to.be.frozen;
+        expect(subject.props.className).to.equal('foo-1');
+      });
+    });
+    context('when the element\'s props are not extensible', () => {
+      it('adds className and props are still not extensible', () => {
+        let subject;
+
+        subject = <div styleName='foo' />;
+
+        Object.preventExtensions(subject.props);
+        subject = linkClass(subject, {
+          foo: 'foo-1'
+        });
+
+        expect(subject.props).to.not.be.extensible;
+        expect(subject.props.className).to.equal('foo-1');
+      });
+    });
+  });
+
+  context('when element is an array', () => {
+    it('handles each element individually', () => {
+      let subject;
+
+      subject = [
+        <div key={1} styleName='foo' />,
+        <div key={2}>
+          <p styleName='bar' />
+        </div>
+      ];
+
+      subject = linkClass(subject, {
+        bar: 'bar-1',
+        foo: 'foo-1'
+      });
+
+      expect(subject).to.be.an('array');
+      expect(subject[0].props.className).to.equal('foo-1');
+      expect(subject[1].props.children.props.className).to.equal('bar-1');
     });
   });
 


### PR DESCRIPTION
Fixes #200, fixes #266, fixes #259. I was getting the extensible error for the props of some elements and I am unable to use `babel-plugin-react-css-modules` in my project.

This issue is blocking an update to the latest version of React 16,  which @evan-scott-zocdoc also seems to be running into in #262. This may also address #112 since the fix is similar.