### PR TITLE
Update outdated webpack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Setup:
 {
     test: /\.css$/,
     loaders: [
-        'style?sourceMap',
-        'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]'
+        'style-loader?sourceMap',
+        'css-loader?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]'
     ]
 }
 ```


### PR DESCRIPTION
It's no longer allowed to omit the '-loader' suffix when using loaders. We need to specify 'style-loader' instead of 'style', and similarly for 'css-loader'