### PR TITLE
Fix Flow "Cannot resolve module" errors on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-css-modules",
   "description": "Seamless mapping of class names to CSS modules inside of React components.",
-  "main": "./dist/",
+  "main": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/gajus/react-css-modules"


### PR DESCRIPTION
Flow on Windows seems to be unable to correctly resolve imports from `react-css-modules` package, because its `main` entry in `package.json` points to a directory, instead of directly pointing to the script `dist/index.js`. 

Fixing it here seems to be easier than looking for a platform specific issue in Flow.