### PR TITLE
Use local copy of props instead of this.props

### DIFF
--- a/src/extendReactClass.js
+++ b/src/extendReactClass.js
@@ -22,11 +22,11 @@ export default (Component: Object, defaultStyles: Object, options: Object) => {
       if (this.props.styles || hasDefaultstyles) {
         const props = Object.assign({}, this.props);
 
-        if (this.props.styles) {
-          styles = this.props.styles;
+        if (props.styles) {
+          styles = props.styles;
         } else if (hasDefaultstyles) {
           styles = defaultStyles;
-          delete this.props.styles;
+          delete props.styles;
         }
 
         Object.defineProperty(props, 'styles', {


### PR DESCRIPTION
Fix for #283

Reasoning: In 'use strict' mode deleting read-only properties throws an error. Since `props.styles` is always overwritten on `this.props` is always overwritten, this should have the same end result with better compatibility.