### PR TITLE
update dependencies for React 16.3+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "hoist-non-react-statics": "^1.2.0",
+    "hoist-non-react-statics": "^2.5.5",
     "lodash": "^4.16.6",
     "object-unfreeze": "^1.1.0"
   },


### PR DESCRIPTION
bump hoist-non-react-statics to >= 2.5.0 to prevent incorrectly hoisted getDerivedStateFromProps

Fixes #288 