### PR TITLE
Fix assign a generated className to elements inside nested arrays

### DIFF
--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -50,14 +50,7 @@ const linkElement = (element: ReactElement, styles: Object, configuration: Objec
   if (React.isValidElement(children)) {
     elementShallowCopy.props.children = linkElement(React.Children.only(children), styles, configuration);
   } else if (_.isArray(children) || isIterable(children)) {
-    elementShallowCopy.props.children = _.map(children, (node) => {
-      if (React.isValidElement(node)) {
-        // eslint-disable-next-line no-use-before-define
-        return linkElement(React.Children.only(node), styles, configuration);
-      } else {
-        return node;
-      }
-    });
+    elementShallowCopy.props.children = linkArray(objectUnfreeze(children), styles, configuration);
   }
 
   _.forEach(restProps, (propValue, propName) => {

--- a/tests/linkClass.js
+++ b/tests/linkClass.js
@@ -125,6 +125,33 @@ describe('linkClass', () => {
         expect(subject.props.children[0].props.className).to.equal('foo-1');
         expect(subject.props.children[1].props.className).to.equal('bar-1');
       });
+      it('assigns a generated className to elements inside nested arrays', () => {
+        let subject;
+
+        subject = <div>
+          {[
+            [
+              <p key='1' styleName='foo' />,
+              <p key='2' styleName='bar' />
+            ],
+            [
+              <p key='1' styleName='foo' />,
+              <p key='2' styleName='bar' />
+            ]
+          ]}
+        </div>;
+
+        subject = linkClass(subject, {
+          bar: 'bar-1',
+          foo: 'foo-1'
+        });
+
+        expect(subject.props.children[0][0].props.className).to.equal('foo-1');
+        expect(subject.props.children[0][1].props.className).to.equal('bar-1');
+
+        expect(subject.props.children[1][0].props.className).to.equal('foo-1');
+        expect(subject.props.children[1][1].props.className).to.equal('bar-1');
+      });
       it('styleName is deleted from props', () => {
         let subject;
 


### PR DESCRIPTION
My previous PR https://github.com/gajus/react-css-modules/pull/286 broke one rare case. I'm sorry for that.

The case is when a component renders elements inside nested arrays. Example:
```
<div>
          {[
            [
              <p key='1' styleName='foo' />,
              <p key='2' styleName='bar' />
            ],
            [
              <p key='1' styleName='foo' />,
              <p key='2' styleName='bar' />
            ]
          ]}
        </div>
```

It worked before my PR because React.Children.map() recursively walks through nested arrays but lodash map doesn't do that. From another point of view, React.Children.map() flattens the array and changes the original structure. 

The best solution I found is already existing function of your library called linkArray(). It also walks through arrays but unlike the React.Children.map() doesn't change the structure. 

Again, I'm sorry for this regression bug. 