### PR TITLE
fix: unfreeze nested children array before passing it to linkArray

### DIFF
--- a/src/linkClass.js
+++ b/src/linkClass.js
@@ -13,7 +13,9 @@ const linkArray = (array: Array, styles: Object, configuration: Object) => {
       // eslint-disable-next-line no-use-before-define
       array[index] = linkElement(React.Children.only(value), styles, configuration);
     } else if (_.isArray(value)) {
-      array[index] = linkArray(value, styles, configuration);
+      const unfreezedValue = Object.isFrozen(value) ? objectUnfreeze(value) : value;
+
+      array[index] = linkArray(unfreezedValue, styles, configuration);
     }
   });
 


### PR DESCRIPTION
When children of decorated component happen to have nested arrays in them:
```
[
el1,
[el2, el3],
el4,
]
```
`linkClass.js:86` unfreezeObject will unfreeze only 1 level in depth (i.e. first array, but not nested one), leading to `TypeError: cannot assign to readonly property 0`.
This PR should fix it by checking if array passed to linkArray recurse call is frozen, unfreezing if necessary.